### PR TITLE
Enable Level-of-Detail (LOD) for all planets in WebAssembly

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -673,6 +673,38 @@ void Application::LoadResources() {
         "resource/textures/Star_Spectrum.dds",
         "resource/textures/flares_bright.dds",
         // Planets
+#ifdef __EMSCRIPTEN__
+        "resource/textures_low/Mercury_Diffuse_Low.dds", "resource/textures_low/Mercury_Normal_Low.dds", "resource/textures_low/Mercury_Specular_Low.dds",
+        "resource/textures_low/Venus_Diffuse_Low.dds", "resource/textures_low/Venus_Normal_Low.dds",
+        "resource/textures_low/Earth_Day_Diffuse_Low.dds", "resource/textures/Earth_Clouds_Diffuse.dds", "resource/textures/Earth_Night_Diffuse.dds", "resource/textures_low/Earth_Normal_Low.dds", "resource/textures_low/Earth_Specular_Low.dds",
+        "resource/textures/Moon_Diffuse.dds", "resource/textures/Moon_Normal.dds",
+        "resource/textures_low/Mars_Diffuse_Low.dds", "resource/textures_low/Mars_Normal_Low.dds",
+        "resource/textures/Phobos_Diffuse.dds", "resource/textures/Phobos_Normal.dds",
+        "resource/textures/Deimos_Diffuse.dds", "resource/textures/Deimos_Normal.dds",
+        "resource/textures_low/Jupiter_Diffuse_Low.dds", "resource/textures_low/Jupiter_Normal_Low.dds",
+        "resource/textures/Io_Diffuse.dds", "resource/textures/Io_Normal.dds",
+        "resource/textures/Europa_Diffuse.dds", "resource/textures/Europa_Normal.dds",
+        "resource/textures/Ganymede_Diffuse.dds", "resource/textures/Ganymede_Normal.dds",
+        "resource/textures/Callisto_Diffuse.dds", "resource/textures/Callisto_Normal.dds",
+        "resource/textures_low/Saturn_Diffuse_Low.dds", "resource/textures_low/Saturn_Normal_Low.dds", "resource/textures/Saturn_Rings.dds",
+        "resource/textures/Mimas_Diffuse.dds", "resource/textures/Mimas_Normal.dds",
+        "resource/textures/Enceladus_Diffuse.dds", "resource/textures/Enceladus_Normal.dds",
+        "resource/textures/Tethys_Diffuse.dds", "resource/textures/Tethys_Normal.dds",
+        "resource/textures/Dione_Diffuse.dds", "resource/textures/Dione_Normal.dds",
+        "resource/textures/Rhea_Diffuse.dds", "resource/textures/Rhea_Normal.dds",
+        "resource/textures/Titan_Diffuse.dds", "resource/textures/Titan_Normal.dds",
+        "resource/textures/Iapetus_Diffuse.dds", "resource/textures/Iapetus_Normal.dds",
+        "resource/textures_low/Uranus_Diffuse_Low.dds", "resource/textures/Uranus_Clouds_Diffuse.dds", "resource/textures_low/Uranus_Normal_Low.dds", "resource/textures/Uranus_Rings.dds", "resource/textures/Uranus_Clouds_Normal.dds",
+        "resource/textures/Miranda_Diffuse.dds", "resource/textures/Miranda_Normal.dds",
+        "resource/textures/Ariel_Diffuse.dds", "resource/textures/Ariel_Normal.dds",
+        "resource/textures/Umbriel_Diffuse.dds", "resource/textures/Umbriel_Normal.dds",
+        "resource/textures/Titania_Diffuse.dds", "resource/textures/Titania_Normal.dds",
+        "resource/textures/Oberon_Diffuse.dds", "resource/textures/Oberon_Normal.dds",
+        "resource/textures_low/Neptune_Diffuse_Low.dds", "resource/textures/Neptune_Clouds_Diffuse.dds", "resource/textures_low/Neptune_Normal_Low.dds", "resource/textures/Neptune_Clouds_Normal.dds",
+        "resource/textures/Triton_Diffuse.dds", "resource/textures/Triton_Normal.dds",
+        "resource/textures_low/Pluto_Diffuse_Low.dds", "resource/textures_low/Pluto_Normal_Low.dds", "resource/textures_low/Pluto_Specular_Low.dds",
+        "resource/textures/Charon_Diffuse.dds", "resource/textures/Charon_Normal.dds", "resource/textures/Charon_Specular.dds",
+#else
         "resource/textures/Mercury_Diffuse.dds", "resource/textures/Mercury_Normal.dds", "resource/textures/Mercury_Specular.dds",
         "resource/textures/Venus_Diffuse.dds", "resource/textures/Venus_Normal.dds",
         "resource/textures/Earth_Day_Diffuse.dds", "resource/textures/Earth_Clouds_Diffuse.dds", "resource/textures/Earth_Night_Diffuse.dds", "resource/textures/Earth_Normal.dds", "resource/textures/Earth_Specular.dds",
@@ -703,6 +735,7 @@ void Application::LoadResources() {
         "resource/textures/Triton_Diffuse.dds", "resource/textures/Triton_Normal.dds",
         "resource/textures/Pluto_Diffuse.dds", "resource/textures/Pluto_Normal.dds", "resource/textures/Pluto_Specular.dds",
         "resource/textures/Charon_Diffuse.dds", "resource/textures/Charon_Normal.dds", "resource/textures/Charon_Specular.dds",
+#endif
         // Sounds
         "resource/sounds/Stellardrone - Galaxies.mp3",
         "resource/sounds/Stellardrone - Mars.mp3",
@@ -807,10 +840,17 @@ void Application::InitStarSystem() {
 }
 
 void Application::InitMercury(const MeshHolder& sphereModel) {
+#ifdef __EMSCRIPTEN__
+    PlanetInfo mercuryInfo(sphereModel, 0.38, *_mainPlanetShader,
+            {
+                TextureImage2D("resource/textures_low/Mercury_Diffuse_Low.dds"),
+            }, TextureImage2D("resource/textures_low/Mercury_Normal_Low.dds"), L"Mercury", L"Меркурий", TextureImage2D("resource/textures_low/Mercury_Specular_Low.dds"));
+#else
     PlanetInfo mercuryInfo(sphereModel, 0.38, *_mainPlanetShader,
             {
                 TextureImage2D("resource/textures/Mercury_Diffuse.dds"),
             }, TextureImage2D("resource/textures/Mercury_Normal.dds"), L"Mercury", L"Меркурий", TextureImage2D("resource/textures/Mercury_Specular.dds"));
+#endif
     shared_ptr<Planet> mercury = make_shared<Mercury>(mercuryInfo, _sun);
 
     const glm::mat4 lightProjection = glm::ortho(-mercury->GetRadius() * 3.0f, mercury->GetRadius() * 3.0f, -mercury->GetRadius() * 3.0f, mercury->GetRadius() * 3.0f, camera.GetNear(), camera.GetFar());
@@ -824,10 +864,17 @@ void Application::InitMercury(const MeshHolder& sphereModel) {
 }
 
 void Application::InitVenus(const MeshHolder& sphereModel) {
+#ifdef __EMSCRIPTEN__
+    PlanetInfo venusInfo(sphereModel, 0.95, *_mainPlanetShader,
+            {
+                TextureImage2D("resource/textures_low/Venus_Diffuse_Low.dds"),
+            }, TextureImage2D("resource/textures_low/Venus_Normal_Low.dds"), L"Venus", L"Венера");
+#else
     PlanetInfo venusInfo(sphereModel, 0.95, *_mainPlanetShader,
             {
                 TextureImage2D("resource/textures/Venus_Diffuse.dds"),
             }, TextureImage2D("resource/textures/Venus_Normal.dds"), L"Venus", L"Венера");
+#endif
     shared_ptr<Planet> venus = make_shared<Venus>(venusInfo, _sun);
 
     AtmosphereInfo venusAtmosphereInfo(sphereModel, *_mainAtmosphereShader, 1.1, glm::vec3(203/255.f, 158/255.f, 69/255.), venus->GetRadius() - 0.00007, 1.995);
@@ -901,10 +948,17 @@ void Application::InitEarthSystem(const MeshHolder& sphereModel) {
 void Application::InitMarsSystem(const MeshHolder& sphereModel) {
     MeshHolder phobosModel("resource/models/phobos.obj"), deimosModel("resource/models/deimos.obj");
 
+#ifdef __EMSCRIPTEN__
+    PlanetInfo marsInfo(sphereModel, 0.53, *_mainPlanetShader,
+            {
+                TextureImage2D("resource/textures_low/Mars_Diffuse_Low.dds"),
+            }, TextureImage2D("resource/textures_low/Mars_Normal_Low.dds"), L"Mars", L"Марс");
+#else
     PlanetInfo marsInfo(sphereModel, 0.53, *_mainPlanetShader,
             {
                 TextureImage2D("resource/textures/Mars_Diffuse.dds"),
             }, TextureImage2D("resource/textures/Mars_Normal.dds"), L"Mars", L"Марс");
+#endif
     shared_ptr<Planet> mars = make_shared<Mars>(marsInfo, _sun);
 
     SatelliteInfo phobosInfo(phobosModel, 0.001768, *_mainPlanetShader, {TextureImage2D("resource/textures/Phobos_Diffuse.dds")}, TextureImage2D("resource/textures/Phobos_Normal.dds"),
@@ -936,10 +990,17 @@ void Application::InitMarsSystem(const MeshHolder& sphereModel) {
 }
 
 void Application::InitJupiterSystem(const MeshHolder& sphereModel) {
+#ifdef __EMSCRIPTEN__
+    PlanetInfo jupiterInfo(sphereModel, 11.2, *_mainPlanetShader,
+            {
+                TextureImage2D("resource/textures_low/Jupiter_Diffuse_Low.dds"),
+            }, TextureImage2D("resource/textures_low/Jupiter_Normal_Low.dds"), L"Jupiter", L"Юпитер");
+#else
     PlanetInfo jupiterInfo(sphereModel, 11.2, *_mainPlanetShader,
             {
                 TextureImage2D("resource/textures/Jupiter_Diffuse.dds"),
             }, TextureImage2D("resource/textures/Jupiter_Normal.dds"), L"Jupiter", L"Юпитер");
+#endif
     shared_ptr<Planet> jupiter = make_shared<Jupiter>(jupiterInfo, _sun);
 
     SatelliteInfo ioInfo(sphereModel, 0.28592, *_mainPlanetShader, {TextureImage2D("resource/textures/Io_Diffuse.dds")}, TextureImage2D("resource/textures/Io_Normal.dds"),
@@ -979,10 +1040,17 @@ void Application::InitJupiterSystem(const MeshHolder& sphereModel) {
 void Application::InitSaturnSystem(const MeshHolder& sphereModel) {
     MeshHolder saturnRingModel("resource/models/saturn_ring.obj");
 
+#ifdef __EMSCRIPTEN__
+    PlanetInfo saturnInfo(sphereModel, 9.14, *_mainPlanetShader,
+            {
+                TextureImage2D("resource/textures_low/Saturn_Diffuse_Low.dds"),
+            }, TextureImage2D("resource/textures_low/Saturn_Normal_Low.dds"), L"Saturn", L"Сатурн");
+#else
     PlanetInfo saturnInfo(sphereModel, 9.14, *_mainPlanetShader,
             {
                 TextureImage2D("resource/textures/Saturn_Diffuse.dds"),
             }, TextureImage2D("resource/textures/Saturn_Normal.dds"), L"Saturn", L"Сатурн");
+#endif
     shared_ptr<Planet> saturn = make_shared<Saturn>(saturnInfo, _sun);
 
     PlanetaryRingInfo saturnRingInfo(saturnRingModel, 22.0, 43.7, *_mainPlanetShader, TextureImage2D("resource/textures/Saturn_Rings.dds")); 
@@ -1045,11 +1113,19 @@ void Application::InitSaturnSystem(const MeshHolder& sphereModel) {
 void Application::InitUranusSystem(const MeshHolder& sphereModel) {
     MeshHolder uranusRingModel("resource/models/uranus_ring.obj");
 
+#ifdef __EMSCRIPTEN__
+    PlanetInfo uranusInfo(sphereModel, 3.98085, *_mainPlanetShader,
+            {
+                TextureImage2D("resource/textures_low/Uranus_Diffuse_Low.dds"),
+                TextureImage2D("resource/textures/Uranus_Clouds_Diffuse.dds")
+            }, TextureImage2D("resource/textures_low/Uranus_Normal_Low.dds"), L"Uranus", L"Уран");
+#else
     PlanetInfo uranusInfo(sphereModel, 3.98085, *_mainPlanetShader,
             {
                 TextureImage2D("resource/textures/Uranus_Diffuse.dds"),
                 TextureImage2D("resource/textures/Uranus_Clouds_Diffuse.dds")
             }, TextureImage2D("resource/textures/Uranus_Normal.dds"), L"Uranus", L"Уран");
+#endif
     shared_ptr<Planet> uranus = make_shared<Uranus>(uranusInfo, _sun);
     PlanetaryRingInfo uranusRingInfo(uranusRingModel, 12.6, 16.0, *_mainPlanetShader, TextureImage2D("resource/textures/Uranus_Rings.dds")); // Radiuses from 3D model
     unique_ptr<PlanetaryRing> uranusRing = make_unique<UranusRing>(uranusRingInfo, uranus);
@@ -1098,11 +1174,19 @@ void Application::InitUranusSystem(const MeshHolder& sphereModel) {
 }
 
 void Application::InitNeptuneSystem(const MeshHolder& sphereModel) {
+#ifdef __EMSCRIPTEN__
+    PlanetInfo neptuneInfo(sphereModel, 3.8647, *_mainPlanetShader,
+            {
+                TextureImage2D("resource/textures_low/Neptune_Diffuse_Low.dds"),
+                TextureImage2D("resource/textures/Neptune_Clouds_Diffuse.dds")
+            }, TextureImage2D("resource/textures_low/Neptune_Normal_Low.dds"), L"Neptune", L"Нептун");
+#else
     PlanetInfo neptuneInfo(sphereModel, 3.8647, *_mainPlanetShader,
             {
                 TextureImage2D("resource/textures/Neptune_Diffuse.dds"),
                 TextureImage2D("resource/textures/Neptune_Clouds_Diffuse.dds")
             }, TextureImage2D("resource/textures/Neptune_Normal.dds"), L"Neptune", L"Нептун");
+#endif
     shared_ptr<Planet> neptune = make_shared<Neptune>(neptuneInfo, _sun);
 
     SatelliteInfo tritonInfo(sphereModel, 0.2724, *_mainPlanetShader, {TextureImage2D("resource/textures/Triton_Diffuse.dds")}, TextureImage2D("resource/textures/Triton_Normal.dds"),
@@ -1136,10 +1220,17 @@ void Application::InitNeptuneSystem(const MeshHolder& sphereModel) {
 }
 
 void Application::InitPlutoSystem(const MeshHolder& sphereModel) {
+#ifdef __EMSCRIPTEN__
+    PlanetInfo plutoInfo(sphereModel, 0.18651, *_mainPlanetShader,
+            {
+                TextureImage2D("resource/textures_low/Pluto_Diffuse_Low.dds"),
+            }, TextureImage2D("resource/textures_low/Pluto_Normal_Low.dds"), L"Pluto", L"Плутон", TextureImage2D("resource/textures_low/Pluto_Specular_Low.dds"));
+#else
     PlanetInfo plutoInfo(sphereModel, 0.18651, *_mainPlanetShader,
             {
                 TextureImage2D("resource/textures/Pluto_Diffuse.dds"),
             }, TextureImage2D("resource/textures/Pluto_Normal.dds"), L"Pluto", L"Плутон", TextureImage2D("resource/textures/Pluto_Specular.dds"));
+#endif
     shared_ptr<Planet> pluto = make_shared<Pluto>(plutoInfo, _sun);
 
     SatelliteInfo charonInfo(sphereModel, 0.09512, *_mainPlanetShader, {TextureImage2D("resource/textures/Charon_Diffuse.dds")}, TextureImage2D("resource/textures/Charon_Normal.dds"),

--- a/src/Solar_System/Jupiter_System/Jupiter.cpp
+++ b/src/Solar_System/Jupiter_System/Jupiter.cpp
@@ -4,6 +4,11 @@ Jupiter::Jupiter(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar)
     _normalMap(planetInfo.normalMap)
 {
     Translate(_parentStar->GetPosition() + glm::vec3(1350.f, 0.0f, 1737.0f)); // Init position for light space matrix
+#ifdef __EMSCRIPTEN__
+    _isHighResLoaded = false;
+#else
+    _isHighResLoaded = true;
+#endif
 }
 
 void Jupiter::AdjustToParent(bool isRunTime) {
@@ -34,4 +39,28 @@ void Jupiter::Render() const {
     glBindTextureUnit(1, _normalMap.GetTexture());
 
     SpaceObject::Render();
+}
+
+void Jupiter::LoadHighResIfClose(const glm::vec3& cameraPos) {
+#ifdef __EMSCRIPTEN__
+    if (_isHighResLoaded) {
+        return;
+    }
+
+    float distance = glm::length(cameraPos - GetPosition());
+
+    if (distance < _lodThreshold) {
+        std::cout << "[LOD] Camera distance to Jupiter: " << distance << " units. Loading high-res textures..." << std::endl;
+
+        try {
+            _diffuses.at(0).ReloadTexture(_diffuseHighPath);
+            _normalMap.ReloadTexture(_normalHighPath);
+
+            _isHighResLoaded = true;
+            std::cout << "[LOD] Jupiter high-res textures loaded successfully" << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "[LOD] ERROR: Failed to load high-res textures for Jupiter: " << e.what() << std::endl;
+        }
+    }
+#endif
 }

--- a/src/Solar_System/Jupiter_System/Jupiter.h
+++ b/src/Solar_System/Jupiter_System/Jupiter.h
@@ -7,10 +7,17 @@ public:
     explicit Jupiter(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar);
     void AdjustToParent(bool isRunTime) override;
     void Render() const override;
+    void LoadHighResIfClose(const glm::vec3& cameraPos) override;
 
 private:
     std::vector<TextureImage2D> _diffuses;
     TextureImage2D _normalMap;
+
+    std::string _diffuseHighPath = "resource/textures/Jupiter_Diffuse.dds";
+    std::string _normalHighPath = "resource/textures/Jupiter_Normal.dds";
+
+    bool _isHighResLoaded = false;
+    const float _lodThreshold = 50.0f;
 };
 
 #endif //SOLARSYSTEM_JUPITER_H

--- a/src/Solar_System/Mars_System/Mars.cpp
+++ b/src/Solar_System/Mars_System/Mars.cpp
@@ -4,6 +4,11 @@ Mars::Mars(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar) : Pla
     _normalMap(planetInfo.normalMap)
 {
     Translate(_parentStar->GetPosition() + glm::vec3(-1732.0f, 0.0f, 1000.0f)); // Init position for light space matrix
+#ifdef __EMSCRIPTEN__
+    _isHighResLoaded = false;
+#else
+    _isHighResLoaded = true;
+#endif
 }
 
 void Mars::AdjustToParent(bool isRunTime) {
@@ -36,3 +41,26 @@ void Mars::Render() const {
     SpaceObject::Render();
 }
 
+void Mars::LoadHighResIfClose(const glm::vec3& cameraPos) {
+#ifdef __EMSCRIPTEN__
+    if (_isHighResLoaded) {
+        return;
+    }
+
+    float distance = glm::length(cameraPos - GetPosition());
+
+    if (distance < _lodThreshold) {
+        std::cout << "[LOD] Camera distance to Mars: " << distance << " units. Loading high-res textures..." << std::endl;
+
+        try {
+            _diffuses.at(0).ReloadTexture(_diffuseHighPath);
+            _normalMap.ReloadTexture(_normalHighPath);
+
+            _isHighResLoaded = true;
+            std::cout << "[LOD] Mars high-res textures loaded successfully" << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "[LOD] ERROR: Failed to load high-res textures for Mars: " << e.what() << std::endl;
+        }
+    }
+#endif
+}

--- a/src/Solar_System/Mars_System/Mars.h
+++ b/src/Solar_System/Mars_System/Mars.h
@@ -7,10 +7,17 @@ public:
     explicit Mars(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar);
     void AdjustToParent(bool isRunTime) override;
     void Render() const override;
+    void LoadHighResIfClose(const glm::vec3& cameraPos) override;
 
 private:
     std::vector<TextureImage2D> _diffuses;
     TextureImage2D _normalMap;
+
+    std::string _diffuseHighPath = "resource/textures/Mars_Diffuse.dds";
+    std::string _normalHighPath = "resource/textures/Mars_Normal.dds";
+
+    bool _isHighResLoaded = false;
+    const float _lodThreshold = 50.0f;
 };
 
 #endif //SOLARSYSTEM_MARS_H

--- a/src/Solar_System/Mercury/Mercury.cpp
+++ b/src/Solar_System/Mercury/Mercury.cpp
@@ -4,6 +4,11 @@ Mercury::Mercury(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar)
     _normalMap(planetInfo.normalMap), _specular(planetInfo.specularTexture)
 {
     Translate(_parentStar->GetPosition() + glm::vec3(1500.f, 0.0f, 350.0f)); // Init position for light space matrix
+#ifdef __EMSCRIPTEN__
+    _isHighResLoaded = false;
+#else
+    _isHighResLoaded = true;
+#endif
 }
 
 void Mercury::AdjustToParent(bool isRunTime) {
@@ -37,3 +42,27 @@ void Mercury::Render() const {
     SpaceObject::Render();
 }
 
+void Mercury::LoadHighResIfClose(const glm::vec3& cameraPos) {
+#ifdef __EMSCRIPTEN__
+    if (_isHighResLoaded) {
+        return;
+    }
+
+    float distance = glm::length(cameraPos - GetPosition());
+
+    if (distance < _lodThreshold) {
+        std::cout << "[LOD] Camera distance to Mercury: " << distance << " units. Loading high-res textures..." << std::endl;
+
+        try {
+            _diffuses.at(0).ReloadTexture(_diffuseHighPath);
+            _normalMap.ReloadTexture(_normalHighPath);
+            _specular.ReloadTexture(_specularHighPath);
+
+            _isHighResLoaded = true;
+            std::cout << "[LOD] Mercury high-res textures loaded successfully" << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "[LOD] ERROR: Failed to load high-res textures for Mercury: " << e.what() << std::endl;
+        }
+    }
+#endif
+}

--- a/src/Solar_System/Mercury/Mercury.h
+++ b/src/Solar_System/Mercury/Mercury.h
@@ -7,10 +7,18 @@ public:
     explicit Mercury(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar);
     void AdjustToParent(bool isRunTime) override;
     void Render() const override;
+    void LoadHighResIfClose(const glm::vec3& cameraPos) override;
 
 private:
     std::vector<TextureImage2D> _diffuses;
     TextureImage2D _normalMap, _specular;
+
+    std::string _diffuseHighPath = "resource/textures/Mercury_Diffuse.dds";
+    std::string _normalHighPath = "resource/textures/Mercury_Normal.dds";
+    std::string _specularHighPath = "resource/textures/Mercury_Specular.dds";
+
+    bool _isHighResLoaded = false;
+    const float _lodThreshold = 50.0f;
 };
 
 

--- a/src/Solar_System/Neptune_System/Neptune.cpp
+++ b/src/Solar_System/Neptune_System/Neptune.cpp
@@ -4,6 +4,11 @@ Neptune::Neptune(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar)
     _normalMap(planetInfo.normalMap)
 {
     Translate(_parentStar->GetPosition() + glm::vec3(-2900.0f, 0.0f, 0.0f)); // Init position for light space matrix
+#ifdef __EMSCRIPTEN__
+    _isHighResLoaded = false;
+#else
+    _isHighResLoaded = true;
+#endif
 }
 
 void Neptune::AdjustToParent(bool isRunTime) {
@@ -39,4 +44,28 @@ void Neptune::Render() const {
     SpaceObject::Render();
 
     GetShader().SetBool("hasClouds", false);
+}
+
+void Neptune::LoadHighResIfClose(const glm::vec3& cameraPos) {
+#ifdef __EMSCRIPTEN__
+    if (_isHighResLoaded) {
+        return;
+    }
+
+    float distance = glm::length(cameraPos - GetPosition());
+
+    if (distance < _lodThreshold) {
+        std::cout << "[LOD] Camera distance to Neptune: " << distance << " units. Loading high-res textures..." << std::endl;
+
+        try {
+            _diffuses.at(0).ReloadTexture(_diffuseHighPath);
+            _normalMap.ReloadTexture(_normalHighPath);
+
+            _isHighResLoaded = true;
+            std::cout << "[LOD] Neptune high-res textures loaded successfully" << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "[LOD] ERROR: Failed to load high-res textures for Neptune: " << e.what() << std::endl;
+        }
+    }
+#endif
 }

--- a/src/Solar_System/Neptune_System/Neptune.h
+++ b/src/Solar_System/Neptune_System/Neptune.h
@@ -7,10 +7,17 @@ public:
     explicit Neptune(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar);
     void AdjustToParent(bool isRunTime) override;
     void Render() const override;
+    void LoadHighResIfClose(const glm::vec3& cameraPos) override;
 
 private:
     std::vector<TextureImage2D> _diffuses;
     TextureImage2D _normalMap;
+
+    std::string _diffuseHighPath = "resource/textures/Neptune_Diffuse.dds";
+    std::string _normalHighPath = "resource/textures/Neptune_Normal.dds";
+
+    bool _isHighResLoaded = false;
+    const float _lodThreshold = 50.0f;
 };
 
 #endif //SOLARSYSTEM_NEPTUNE_H

--- a/src/Solar_System/Pluto_System/Pluto.cpp
+++ b/src/Solar_System/Pluto_System/Pluto.cpp
@@ -4,6 +4,11 @@ Pluto::Pluto(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar) : P
     _normalMap(planetInfo.normalMap), _specular(planetInfo.specularTexture)
 {
     Translate(_parentStar->GetPosition() + glm::vec3(2800.0f, 0.0f, 1757.73f)); // Init position for light space matrix
+#ifdef __EMSCRIPTEN__
+    _isHighResLoaded = false;
+#else
+    _isHighResLoaded = true;
+#endif
 }
 
 void Pluto::AdjustToParent(bool isRunTime) {
@@ -35,4 +40,29 @@ void Pluto::Render() const {
     glBindTextureUnit(2, _specular.GetTexture());
 
     SpaceObject::Render();
+}
+
+void Pluto::LoadHighResIfClose(const glm::vec3& cameraPos) {
+#ifdef __EMSCRIPTEN__
+    if (_isHighResLoaded) {
+        return;
+    }
+
+    float distance = glm::length(cameraPos - GetPosition());
+
+    if (distance < _lodThreshold) {
+        std::cout << "[LOD] Camera distance to Pluto: " << distance << " units. Loading high-res textures..." << std::endl;
+
+        try {
+            _diffuses.at(0).ReloadTexture(_diffuseHighPath);
+            _normalMap.ReloadTexture(_normalHighPath);
+            _specular.ReloadTexture(_specularHighPath);
+
+            _isHighResLoaded = true;
+            std::cout << "[LOD] Pluto high-res textures loaded successfully" << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "[LOD] ERROR: Failed to load high-res textures for Pluto: " << e.what() << std::endl;
+        }
+    }
+#endif
 }

--- a/src/Solar_System/Pluto_System/Pluto.h
+++ b/src/Solar_System/Pluto_System/Pluto.h
@@ -7,10 +7,18 @@ public:
     explicit Pluto(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar);
     void AdjustToParent(bool isRunTime) override;
     void Render() const override;
+    void LoadHighResIfClose(const glm::vec3& cameraPos) override;
 
 private:
     std::vector<TextureImage2D> _diffuses;
     TextureImage2D _normalMap, _specular;
+
+    std::string _diffuseHighPath = "resource/textures/Pluto_Diffuse.dds";
+    std::string _normalHighPath = "resource/textures/Pluto_Normal.dds";
+    std::string _specularHighPath = "resource/textures/Pluto_Specular.dds";
+
+    bool _isHighResLoaded = false;
+    const float _lodThreshold = 50.0f;
 };
 
 #endif //SOLARSYSTEM_PLUTO_H

--- a/src/Solar_System/Saturn_System/Saturn.cpp
+++ b/src/Solar_System/Saturn_System/Saturn.cpp
@@ -4,6 +4,11 @@ Saturn::Saturn(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar) :
 _normalMap(planetInfo.normalMap)
 {
     Translate(_parentStar->GetPosition() + glm::vec3(0.0f, -100.f, 2450.0f)); // Init position for light space matrix
+#ifdef __EMSCRIPTEN__
+    _isHighResLoaded = false;
+#else
+    _isHighResLoaded = true;
+#endif
 }
 
 void Saturn::AdjustToParent(bool isRunTime) {
@@ -35,4 +40,28 @@ void Saturn::Render() const {
     glBindTextureUnit(1, _normalMap.GetTexture());
 
     SpaceObject::Render();
+}
+
+void Saturn::LoadHighResIfClose(const glm::vec3& cameraPos) {
+#ifdef __EMSCRIPTEN__
+    if (_isHighResLoaded) {
+        return;
+    }
+
+    float distance = glm::length(cameraPos - GetPosition());
+
+    if (distance < _lodThreshold) {
+        std::cout << "[LOD] Camera distance to Saturn: " << distance << " units. Loading high-res textures..." << std::endl;
+
+        try {
+            _diffuses.at(0).ReloadTexture(_diffuseHighPath);
+            _normalMap.ReloadTexture(_normalHighPath);
+
+            _isHighResLoaded = true;
+            std::cout << "[LOD] Saturn high-res textures loaded successfully" << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "[LOD] ERROR: Failed to load high-res textures for Saturn: " << e.what() << std::endl;
+        }
+    }
+#endif
 }

--- a/src/Solar_System/Saturn_System/Saturn.h
+++ b/src/Solar_System/Saturn_System/Saturn.h
@@ -7,10 +7,17 @@ public:
     explicit Saturn(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar);
     void AdjustToParent(bool isRunTime) override;
     void Render() const override;
+    void LoadHighResIfClose(const glm::vec3& cameraPos) override;
 
 private:
     std::vector<TextureImage2D> _diffuses;
     TextureImage2D _normalMap;
+
+    std::string _diffuseHighPath = "resource/textures/Saturn_Diffuse.dds";
+    std::string _normalHighPath = "resource/textures/Saturn_Normal.dds";
+
+    bool _isHighResLoaded = false;
+    const float _lodThreshold = 50.0f;
 };
 
 #endif //SOLARSYSTEM_SATURN_H

--- a/src/Solar_System/Uranus_System/Uranus.cpp
+++ b/src/Solar_System/Uranus_System/Uranus.cpp
@@ -4,6 +4,11 @@ Uranus::Uranus(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar) :
     _normalMap(planetInfo.normalMap)
 {
     Translate(_parentStar->GetPosition() + glm::vec3(0.0f, 0.0f, -2650.0f)); // Init position for light space matrix
+#ifdef __EMSCRIPTEN__
+    _isHighResLoaded = false;
+#else
+    _isHighResLoaded = true;
+#endif
 }
 
 void Uranus::AdjustToParent(bool isRunTime) {
@@ -39,4 +44,28 @@ void Uranus::Render() const {
     SpaceObject::Render();
 
     GetShader().SetBool("hasClouds", false);
+}
+
+void Uranus::LoadHighResIfClose(const glm::vec3& cameraPos) {
+#ifdef __EMSCRIPTEN__
+    if (_isHighResLoaded) {
+        return;
+    }
+
+    float distance = glm::length(cameraPos - GetPosition());
+
+    if (distance < _lodThreshold) {
+        std::cout << "[LOD] Camera distance to Uranus: " << distance << " units. Loading high-res textures..." << std::endl;
+
+        try {
+            _diffuses.at(0).ReloadTexture(_diffuseHighPath);
+            _normalMap.ReloadTexture(_normalHighPath);
+
+            _isHighResLoaded = true;
+            std::cout << "[LOD] Uranus high-res textures loaded successfully" << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "[LOD] ERROR: Failed to load high-res textures for Uranus: " << e.what() << std::endl;
+        }
+    }
+#endif
 }

--- a/src/Solar_System/Uranus_System/Uranus.h
+++ b/src/Solar_System/Uranus_System/Uranus.h
@@ -7,10 +7,17 @@ public:
     explicit Uranus(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar);
     void AdjustToParent(bool isRunTime) override;
     void Render() const override;
+    void LoadHighResIfClose(const glm::vec3& cameraPos) override;
 
 private:
     std::vector<TextureImage2D> _diffuses;
     TextureImage2D _normalMap;
+
+    std::string _diffuseHighPath = "resource/textures/Uranus_Diffuse.dds";
+    std::string _normalHighPath = "resource/textures/Uranus_Normal.dds";
+
+    bool _isHighResLoaded = false;
+    const float _lodThreshold = 50.0f;
 };
 
 #endif //SOLARSYSTEM_URANUS_H

--- a/src/Solar_System/Venus/Venus.cpp
+++ b/src/Solar_System/Venus/Venus.cpp
@@ -4,6 +4,11 @@ Venus::Venus(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar) : P
     _normalMap(planetInfo.normalMap)
 {
     Translate(_parentStar->GetPosition() + glm::vec3(1125.0f, 0.0f, -1340.0f)); // Init position for light space matrix
+#ifdef __EMSCRIPTEN__
+    _isHighResLoaded = false;
+#else
+    _isHighResLoaded = true;
+#endif
 }
 
 void Venus::AdjustToParent(bool isRunTime) {
@@ -36,3 +41,26 @@ void Venus::Render() const {
     SpaceObject::Render();
 }
 
+void Venus::LoadHighResIfClose(const glm::vec3& cameraPos) {
+#ifdef __EMSCRIPTEN__
+    if (_isHighResLoaded) {
+        return;
+    }
+
+    float distance = glm::length(cameraPos - GetPosition());
+
+    if (distance < _lodThreshold) {
+        std::cout << "[LOD] Camera distance to Venus: " << distance << " units. Loading high-res textures..." << std::endl;
+
+        try {
+            _diffuses.at(0).ReloadTexture(_diffuseHighPath);
+            _normalMap.ReloadTexture(_normalHighPath);
+
+            _isHighResLoaded = true;
+            std::cout << "[LOD] Venus high-res textures loaded successfully" << std::endl;
+        } catch (const std::exception& e) {
+            std::cerr << "[LOD] ERROR: Failed to load high-res textures for Venus: " << e.what() << std::endl;
+        }
+    }
+#endif
+}

--- a/src/Solar_System/Venus/Venus.h
+++ b/src/Solar_System/Venus/Venus.h
@@ -7,10 +7,17 @@ public:
     explicit Venus(const PlanetInfo& planetInfo, std::shared_ptr<Star> parentStar);
     void AdjustToParent(bool isRunTime) override;
     void Render() const override;
+    void LoadHighResIfClose(const glm::vec3& cameraPos) override;
 
 private:
     std::vector<TextureImage2D> _diffuses;
     TextureImage2D _normalMap;
+
+    std::string _diffuseHighPath = "resource/textures/Venus_Diffuse.dds";
+    std::string _normalHighPath = "resource/textures/Venus_Normal.dds";
+
+    bool _isHighResLoaded = false;
+    const float _lodThreshold = 50.0f;
 };
 
 #endif //SOLARSYSTEM_VENUS_H


### PR DESCRIPTION
This PR extends the Level-of-Detail (LOD) system, initially implemented for Earth, to all other major planets in the solar system.

**Changes:**
1.  **Low-Res Preloading:** The `Application::LoadResources` function now conditionally loads textures from `resource/textures_low/` instead of `resource/textures/` when compiling for Emscripten. This ensures that the initial download is lightweight.
2.  **Planet Initialization:** All `Init[Planet]System` functions in `Application.cpp` now initialize their respective `Planet` objects with low-res texture paths in WebAssembly builds.
3.  **LOD Logic:** Each `Planet` subclass (`Mercury`, `Venus`, `Mars`, `Jupiter`, `Saturn`, `Uranus`, `Neptune`, `Pluto`) now implements `LoadHighResIfClose`. This method checks the distance between the camera and the planet. If the camera is within a threshold (50.0 units), it triggers a reload of the planet's textures (Diffuse, Normal, and Specular where applicable) using the high-resolution assets.
4.  **State Management:** A boolean flag `_isHighResLoaded` prevents redundant texture reloading.

**Impact:**
-   **WebAssembly:** Faster initial load time due to smaller texture assets. High-res textures are loaded on-demand, causing a brief pause only when visiting a planet up close for the first time.
-   **Desktop:** No change in behavior (always loads high-res).

**Testing:**
-   Verified successful compilation and linking using `./build-web.sh`.
-   Verified code structure aligns with the existing Earth LOD implementation.

---
*PR created automatically by Jules for task [15092881217665476442](https://jules.google.com/task/15092881217665476442) started by @ford442*