### PR TITLE
fix: remove unused variables in main.ts

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -7,13 +7,9 @@ const progressBar = document.getElementById('progress-bar') as HTMLElement;
 const progressText = document.getElementById('progress-text') as HTMLElement;
 
 // Global progress tracking
-let totalResources = 0;
-let loadedResources = 0;
 
 // Function to update progress bar
 function updateProgress(loaded: number, total: number) {
-    loadedResources = loaded;
-    totalResources = total;
     
     const percentage = total > 0 ? Math.round((loaded / total) * 100) : 0;
     


### PR DESCRIPTION
Removed unused variables `totalResources` and `loadedResources` from `web/src/main.ts` to resolve TypeScript TS6133 errors. These variables were assigned values but never read, as the progress bar logic relies entirely on the function arguments. This cleanup eliminates redundant state and compiler warnings.

---
*PR created automatically by Jules for task [14016058865158700830](https://jules.google.com/task/14016058865158700830) started by @ford442*