### PR TITLE
Fix shader compilation errors - move #version directive to first line

### DIFF
--- a/resource/shaders/atmosphere.fs
+++ b/resource/shaders/atmosphere.fs
@@ -1,3 +1,5 @@
+#version 300 es
+
 //
 // Atmospheric scattering fragment shader
 //
@@ -5,8 +7,6 @@
 //
 // Copyright (c) 2004 Sean O'Neil
 //
-
-#version 300 es
 precision highp float;
 precision highp int;
 

--- a/resource/shaders/atmosphere.vs
+++ b/resource/shaders/atmosphere.vs
@@ -1,3 +1,5 @@
+#version 300 es
+
 //
 // Atmospheric scattering vertex shader
 //
@@ -5,8 +7,6 @@
 //
 // Copyright (c) 2004 Sean O'Neil
 //
-
-#version 300 es
 
 layout (location = 0) in vec3 aPos;
 


### PR DESCRIPTION
The GLSL compiler requires the #version directive to be the first line in shader files. Comments before #version were causing compilation errors:
  - ERROR: '#version directive must occur on the first line of the shader'
  - ERROR: 'layout' : syntax error

Moved copyright comments after #version in both atmosphere.vs and atmosphere.fs.

https://claude.ai/code/session_01T2ADxse2Cc37a8ShNbcVhy