### PR TITLE
Fix shader compilation error in atmosphere.fs

### DIFF
--- a/resource/shaders/atmosphere.fs
+++ b/resource/shaders/atmosphere.fs
@@ -51,10 +51,10 @@ const int numInScatter = 4;
 const float fNumInScatter = 4.0;
 
 uniform float SCALE_H_FACTOR;
-uniform float SCALE_L_FACTOR = 1.0;
+uniform float SCALE_L_FACTOR;
 
-float SCALE_H = SCALE_H_FACTOR / (outerRadius - innerRadius);
-float SCALE_L = SCALE_L_FACTOR / (outerRadius - innerRadius);
+#define SCALE_H (SCALE_H_FACTOR / (outerRadius - innerRadius))
+#define SCALE_L (SCALE_L_FACTOR / (outerRadius - innerRadius))
 
 out vec4 fragColor;
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -281,6 +281,7 @@ void Application::RenderAtmospheres(const std::vector<RenderableAtmosphere>& ren
             _mainAtmosphereShader->SetVec3("lightPos", _sun->GetPosition() - renderableAtmosphere.atmosphere->GetPosition());
             _mainAtmosphereShader->SetVec3("mieTint", renderableAtmosphere.atmosphere->GetMieTint());
             _mainAtmosphereShader->SetFloat("SCALE_H_FACTOR", renderableAtmosphere.hScaleFactor);
+            _mainAtmosphereShader->SetFloat("SCALE_L_FACTOR", 1.0f);
             _mainAtmosphereShader->SetFloat("earthSizeCoefficient", renderableAtmosphere.parentEarthSizeCoefficient);
             _mainAtmosphereShader->SetBool("isUseToneMapping", renderableAtmosphere.isUseToneMapping);
             _mainAtmosphereShader->SetBool("isNearbyPlanetaryRing", ring != nullptr);

--- a/web/public/resource/shaders/atmosphere.fs
+++ b/web/public/resource/shaders/atmosphere.fs
@@ -1,3 +1,5 @@
+#version 300 es
+
 //
 // Atmospheric scattering fragment shader
 //
@@ -5,8 +7,6 @@
 //
 // Copyright (c) 2004 Sean O'Neil
 //
-
-#version 300 es
 precision highp float;
 precision highp int;
 
@@ -51,10 +51,10 @@ const int numInScatter = 4;
 const float fNumInScatter = 4.0;
 
 uniform float SCALE_H_FACTOR;
-uniform float SCALE_L_FACTOR = 1.0;
+uniform float SCALE_L_FACTOR;
 
-float SCALE_H = SCALE_H_FACTOR / (outerRadius - innerRadius);
-float SCALE_L = SCALE_L_FACTOR / (outerRadius - innerRadius);
+#define SCALE_H (SCALE_H_FACTOR / (outerRadius - innerRadius))
+#define SCALE_L (SCALE_L_FACTOR / (outerRadius - innerRadius))
 
 out vec4 fragColor;
 

--- a/web/public/resource/shaders/atmosphere.vs
+++ b/web/public/resource/shaders/atmosphere.vs
@@ -1,3 +1,5 @@
+#version 300 es
+
 //
 // Atmospheric scattering vertex shader
 //
@@ -5,8 +7,6 @@
 //
 // Copyright (c) 2004 Sean O'Neil
 //
-
-#version 300 es
 
 layout (location = 0) in vec3 aPos;
 


### PR DESCRIPTION
Removed the initial value assigned to SCALE_L_FACTOR uniform and instead
calculate SCALE_H and SCALE_L utilizing #define. Also added uniform set
for SCALE_L_FACTOR in the Application class for correctly getting the default value.

---
*PR created automatically by Jules for task [15086088273923682358](https://jules.google.com/task/15086088273923682358) started by @ford442*