### PR TITLE
Fix shader float comparison in planetaryRingLighting.fs

### DIFF
--- a/resource/shaders/planetaryRingLighting.fs
+++ b/resource/shaders/planetaryRingLighting.fs
@@ -134,7 +134,7 @@ void main() {
 
     vec4 ringColor = texture(ringTexture, texCoords);
 
-    if (ringColor.w == 0)
+    if (ringColor.w == 0.0)
         discard;
 
     const float smoothingAmount = 0.0001;

--- a/web/public/resource/shaders/planetaryRingLighting.fs
+++ b/web/public/resource/shaders/planetaryRingLighting.fs
@@ -134,7 +134,7 @@ void main() {
 
     vec4 ringColor = texture(ringTexture, texCoords);
 
-    if (ringColor.w == 0)
+    if (ringColor.w == 0.0)
         discard;
 
     const float smoothingAmount = 0.0001;


### PR DESCRIPTION
Changed ringColor.w == 0 to ringColor.w == 0.0 to match GLSL float type requirements and fix compilation error.

https://claude.ai/code/session_01BYyfweWp2byozu3mdJAvRn