### PR TITLE
Fix sphere.obj loading crash in WASM build

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -693,6 +693,8 @@ void Application::UpdateLoadingProgress() {
 
 void Application::LoadResources() {
     const std::vector<std::string> resources = {
+        // Models
+        "resource/models/sphere.obj",
         // SkyBox
         "resource/textures/Main_SkyBox/PositiveX.dds",
         "resource/textures/Main_SkyBox/NegativeX.dds",
@@ -858,7 +860,7 @@ void Application::InitSongList() {
 }
 
 void Application::InitStarSystem() {
-    MeshHolder sphereModel("https://test.1ink.us/solar-system/resource/models/sphere.obj");
+    MeshHolder sphereModel("resource/models/sphere.obj");
 
     StarInfo sunInfo(sphereModel, *_mainStarShader, Shader("resource/shaders/starGlow.vs", "resource/shaders/starGlow.fs"), TextureImage2D("resource/textures/Star_Spectrum.dds"),
                      starTemperatureInKelvin, 696342.0, glm::vec3(0.99607843, 0.890196078, 0.725490196), L"Sun", L"Солнце"); 


### PR DESCRIPTION
## Summary
- **Root cause:** `sphere.obj` was not included in the `LoadResources()` pre-download list, so `InitSceneObjects()` attempted a synchronous `emscripten_wget_data` call which aborted with "Please compile your program with async support"
- Added `resource/models/sphere.obj` to the async resource download list so it's fetched alongside textures during the loading screen
- Changed `MeshHolder` call from full URL (`https://test.1ink.us/solar-system/resource/models/sphere.obj`) to local MEMFS path (`resource/models/sphere.obj`), consistent with how all other resources are referenced

## Test plan
- [ ] Verify the loading screen shows progress for 64 resources (was 63)
- [ ] Verify scene initializes without the `emscripten_wget_data` abort error
- [ ] Verify sphere mesh loads correctly and planets render properly

https://claude.ai/code/session_01924ba2g7pcZNrSsgYPWURC