### PR TITLE
Fix WebGL mipmap errors for S3TC compressed textures

### DIFF
--- a/src/3rdparty/nv_dds.cpp
+++ b/src/3rdparty/nv_dds.cpp
@@ -896,13 +896,31 @@ void CDDSImage::upload_texture2D(uint32_t imageIndex, uint32_t target) {
             target == GL_TEXTURE_2D || (target >= GL_TEXTURE_CUBE_MAP_POSITIVE_X && target <= GL_TEXTURE_CUBE_MAP_NEGATIVE_Z));
 
     if (is_compressed()) {
+        // Clear any pending GL error before uploading so we get clean error feedback.
+        glGetError();
+
         glCompressedTexImage2D(target, 0, m_format, image.get_width(), image.get_height(), 0, image.get_size(), image);
+        {
+            GLenum err = glGetError();
+            if (err != GL_NO_ERROR) {
+                fprintf(stderr, "nv_dds: glCompressedTexImage2D level 0 failed (format 0x%X, %ux%u, size %u): GL error 0x%X\n",
+                        m_format, image.get_width(), image.get_height(), image.get_size(), err);
+            }
+        }
 
         // load all mipmaps
         for (unsigned int i = 0; i < image.get_num_mipmaps(); i++) {
             const CSurface &mipmap = image.get_mipmap(i);
 
             glCompressedTexImage2D(target, i + 1, m_format, mipmap.get_width(), mipmap.get_height(), 0, mipmap.get_size(), mipmap);
+            {
+                GLenum err = glGetError();
+                if (err != GL_NO_ERROR) {
+                    fprintf(stderr, "nv_dds: glCompressedTexImage2D mipmap level %u failed (format 0x%X, %ux%u, size %u): GL error 0x%X\n",
+                            i + 1, m_format, mipmap.get_width(), mipmap.get_height(), mipmap.get_size(), err);
+                    break;  // stop uploading further levels to prevent cascade
+                }
+            }
         }
     } else {
         GLint alignment = -1;

--- a/src/Auxiliary_Modules/TextureImage2D.cpp
+++ b/src/Auxiliary_Modules/TextureImage2D.cpp
@@ -12,12 +12,17 @@ void TextureImage2D::LoadTextureFromFile(const std::string& path, GLint wrapPara
     glGenTextures(1, &_textureID);
     glBindTexture(GL_TEXTURE_2D, _textureID);
 
+    bool isCompressed = false;
+    bool hasEmbeddedMipmaps = false;
+
     try {
         // [PORTING NOTE]
         // Ensure files are preloaded (emcc --preload-file) or fetched asynchronously.
         // For preloaded files, std::ifstream in CDDSImage will work transparently.
         CDDSImage image;
         image.load(path, false);
+        isCompressed = image.is_compressed();
+        hasEmbeddedMipmaps = (image.get_num_mipmaps() > 0);
         image.upload_texture2D();
         _width = image.get_width();
         _height = image.get_height();
@@ -26,12 +31,33 @@ void TextureImage2D::LoadTextureFromFile(const std::string& path, GLint wrapPara
         throw std::runtime_error("Image " + path + " cannot be loaded");
     }
 
-    glGenerateMipmap(GL_TEXTURE_2D);
-    GLenum err = glGetError();
-    if (err == GL_INVALID_OPERATION) {
-        // Some texture formats don't support mipmap generation (e.g., some DDS formats)
-        // Fall back to non-mipmapped filtering
-        std::cerr << "Warning: Texture format for " << path << " does not support mipmap generation" << std::endl;
+    // S3TC compressed textures (DXT1/3/5) do not support glGenerateMipmap in WebGL 2.
+    // Mipmaps must be pre-embedded in the DDS file. Only attempt generation for
+    // uncompressed textures that have no embedded mipmaps.
+    if (!isCompressed) {
+        glGenerateMipmap(GL_TEXTURE_2D);
+        GLenum err = glGetError();
+        if (err != GL_NO_ERROR) {
+            std::cerr << "Warning: glGenerateMipmap failed for " << path
+                      << " (error 0x" << std::hex << err << std::dec << ")" << std::endl;
+        } else {
+            hasEmbeddedMipmaps = true;
+        }
+    }
+
+    // If no mipmaps are available (neither generated nor embedded), using any
+    // mipmap min-filter makes the texture "incomplete" — degrade to GL_LINEAR.
+    if (!hasEmbeddedMipmaps) {
+        bool minFilterUsesMipmaps =
+            (minFilter == GL_NEAREST_MIPMAP_NEAREST ||
+             minFilter == GL_LINEAR_MIPMAP_NEAREST  ||
+             minFilter == GL_NEAREST_MIPMAP_LINEAR  ||
+             minFilter == GL_LINEAR_MIPMAP_LINEAR);
+        if (minFilterUsesMipmaps) {
+            std::cerr << "Warning: No mipmaps for " << path
+                      << " -- falling back min filter to GL_LINEAR" << std::endl;
+            minFilter = GL_LINEAR;
+        }
     }
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrapParam);


### PR DESCRIPTION
S3TC/DXT compressed textures do not support glGenerateMipmap in WebGL 2. The old code called it unconditionally then still set GL_LINEAR_MIPMAP_LINEAR even after the call failed, making every texture incomplete and cascading into GL_OUT_OF_MEMORY and context loss.

TextureImage2D.cpp:
- Capture is_compressed() and get_num_mipmaps() from CDDSImage before it goes out of scope
- Skip glGenerateMipmap entirely for compressed textures (DXT1/3/5)
- Fall back minFilter from any GL_*_MIPMAP_* variant to GL_LINEAR when no mipmaps are available, preventing incomplete texture objects

nv_dds.cpp (upload_texture2D):
- Clear pending GL error state before uploading to ensure clean feedback
- Check glGetError() after glCompressedTexImage2D for level 0; log on failure
- Check glGetError() after each mipmap level upload; break loop on first failure to prevent cascading GL errors from poisoning subsequent state

https://claude.ai/code/session_01BaCJUmkWspob1zPZZMQsjw