### PR TITLE
Fix build error: make PlanetSystemManifest copyable

### DIFF
--- a/src/Application.h
+++ b/src/Application.h
@@ -47,7 +47,12 @@ struct PlanetSystemManifest {
     std::function<void()> initFunc;         // Calls InitXxxSystem()
 
     enum class State { NOT_LOADED, DOWNLOADING, READY } state = State::NOT_LOADED;
-    std::atomic<int> pendingDownloads{0};   // Counts only required assets
+    // Counts only required assets. Decremented in download completion callbacks,
+    // which run on the main thread (emscripten_async_wget2 onload/onerror and the
+    // native synchronous stub), so no atomic/locking is needed. Keeping this a
+    // plain int also keeps PlanetSystemManifest copyable, which is required for
+    // the brace-initializer-list assignment of _planetSystemManifests.
+    int pendingDownloads{0};
     int totalDownloads{0};
 };
 


### PR DESCRIPTION
## Problem

The build failed with:

```
.../c++/v1/__vector/vector.h:287:5: error: no matching member function for call to 'assign'
  287 |     assign(__il.begin(), __il.end());
```

The error surfaced inside `<vector>`, but that's just the template instantiation point — the real cause is in our code.

## Root cause

In commit `8b45270` (texture management & LOD improvements), `PlanetSystemManifest` in `src/Application.h` gained:

```cpp
std::atomic<int> pendingDownloads{0};
```

`std::atomic` has a **deleted copy constructor**, which makes the whole struct non-copyable. However, `_planetSystemManifests` is populated via a brace-initializer list:

```cpp
_planetSystemManifests = { {...}, {...}, ... };
```

`std::initializer_list` elements are `const` and must be **copied** into the vector's storage. With a non-copyable element type, `vector`'s internal `assign(__il.begin(), __il.end())` has no valid overload, producing the error above.

## Fix

The callbacks that mutate `pendingDownloads` all run on the main thread:
- `emscripten_async_wget2` `onload`/`onerror` callbacks fire on the main browser thread
- the native `DownloadFile` stub invokes its callback synchronously

So there is no concurrent access and `std::atomic` is unnecessary. Changing it to a plain `int` restores copyability and fixes the build. Verified with a minimal standalone reproduction (atomic → error, int → compiles).

The separate `Application::_resourcesPending` atomic member is untouched, so the `<atomic>` include remains.

https://claude.ai/code/session_01Jf4YnByGwCX3JXQmyVtj9o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jf4YnByGwCX3JXQmyVtj9o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data structure handling for download management. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->