### PR TITLE
Set up Cursor Cloud dev environment for the web (WASM) target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -524,4 +524,29 @@ Runtime assets (textures, sounds) are expected to be served from the same origin
 
 ---
 
-*Last updated: 2026-04-28*
+## 16. Cursor Cloud specific instructions
+
+This section captures non-obvious, durable facts for running this project in a Cursor Cloud VM. The startup update script only refreshes the web frontend's npm deps (`npm install --prefix web`); all heavy toolchain/build state below is expected to persist in the VM snapshot.
+
+### Runnable target
+- **Only the web (WASM) target is runnable in this Linux cloud env.** The native desktop build (`./build.sh`) links Windows-only libs (`glew32`, `OpenGL32`, `irrKlang`, `mingw32`) and will not build/run here. Scope all work to the web target.
+
+### Emscripten toolchain (preinstalled, persisted in snapshot)
+- Emscripten SDK lives at `/content/build_space/emsdk` (version 6.0.0). `build-web.sh` and `setup_web_dependencies.sh` auto-source it from that path, so `./build-web.sh` works without arguments. If `emcc` is already on PATH you can also use `./build-web.sh --no-emsdk`.
+- WASM dependencies (GLM headers + the Assimp static lib `external/assimp/build-wasm/lib/libassimp.a`) are prebuilt under `external/` and also persist in the snapshot. `setup_web_dependencies.sh` is idempotent and skips work if they already exist.
+- If the toolchain or `external/` is ever missing, re-create with: `git clone https://github.com/emscripten-core/emsdk /content/build_space/emsdk && (cd /content/build_space/emsdk && ./emsdk install latest && ./emsdk activate latest)` then `./build-web.sh`.
+
+### Build / lint / run (web)
+- Rebuild WASM after C++/CMake changes: `./build-web.sh` (copies `SolarSystem.js` → `web/src/`, `SolarSystem.wasm`/`SolarSystem.data` → `web/public/`). This is the slow path; only needed for C++ changes.
+- Frontend typecheck (closest thing to lint): `cd web && npx tsc`. Frontend bundle build: `cd web && npx vite build` (or `npm run build`, which first re-runs the full WASM build via `build:emcc`).
+- **Run (dev):** `cd web && npm run dev` → open `http://localhost:5173/solar-system/` (note the `/solar-system/` base path; `/` alone 404s). TypeScript edits hot-reload; C++ edits require a `./build-web.sh` rebuild + refresh.
+- **Run (preview/prod):** `cd web && npm run preview` → `http://localhost:4173/solar-system/` (serves the `dist/` build).
+- No automated test suite exists; verification is manual/visual.
+
+### Asset / rendering caveats (important — avoid false "broken" conclusions)
+- Only **4×4 placeholder** low-res DDS textures are committed; the real planet textures and the skybox are hosted on a remote server (`https://test.1ink.us/solar-system/`) that is currently unreachable (404/CORS). **Therefore planet surfaces and the skybox do not render locally.** What *does* render and proves the engine works: the procedural **Sun** (corona, HDR glow, lens flare) and the 3D distance **labels**, plus full first-person camera navigation.
+- In **dev** mode, `web/src/main.ts` forces all runtime asset fetches to the remote URL (`REMOTE_ASSET_BASE`), so even local placeholder textures are not used. **preview** mode uses the local base URL, so it fetches the bundled placeholder textures (copied to `web/public/resource/textures_low/`).
+- The on-screen **FPS counter often reads 0**: this is `requestAnimationFrame` throttling when the canvas/tab is not focused, **not** a freeze. Confirm liveness by checking that labels move when you move the mouse / press WASD.
+- Planets load lazily via staged loading only when the camera flies within their activation radius (800–1500 units) of huge orbital distances. For testing you can teleport instantly with the exposed JS binding `window.setCameraPose(x, y, z, yaw, pitch)` (the Sun is at the origin; yaw=0 looks +X, yaw=90 looks +Z).
+
+*Last updated: 2026-06-22*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for **SolarSystem-3D-WASM**, scoped to the runnable **web (WebAssembly)** target. The native desktop build is not runnable in this Linux cloud VM (it links Windows-only libs: `glew32`, `OpenGL32`, `irrKlang`, `mingw32`), so all setup targets the Emscripten/Vite web pipeline.

The only code change is documentation: a new `## 16. Cursor Cloud specific instructions` section in `AGENTS.md` capturing durable, non-obvious caveats for future agents. Heavy toolchain/build state (Emscripten SDK, GLM/Assimp WASM deps, built WASM artifacts) lives in the VM snapshot; the startup update script only refreshes web npm deps.

## What was set up
- Installed Emscripten SDK 6.0.0 at `/content/build_space/emsdk` (auto-sourced by `build-web.sh` / `setup_web_dependencies.sh`).
- Built WASM deps via `setup_web_dependencies.sh` (GLM headers + `libassimp.a`) and the full project via `build-web.sh`.
- Installed web frontend npm deps (`web/`).
- **Update script:** `npm install --prefix web`.

## Verification (web target)
- ✅ `./build-web.sh` (Emscripten WASM build → artifacts deployed to `web/`)
- ✅ `npx tsc` (TypeScript typecheck)
- ✅ `npx vite build` (frontend production bundle)
- ✅ `npm run dev` → `http://localhost:5173/solar-system/` (app loads, WASM initializes, render loop runs, camera navigation works)
- ✅ `npm run preview` → `http://localhost:4173/solar-system/`

## Hello-world demo
Loaded the app and performed live first-person navigation (mouse-look + W to fly toward the Sun). The 3D engine renders the Sun (corona, HDR glow, lens flare) and 3D planet labels, and responds interactively.

<a href="https://cursor.com/agents/bc-75d88d45-1dbd-46c2-8b34-984017d2f7ed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsolar_system_dev_navigation.mp4"><img src="https://cursor.com/artifacts/c/art-937a151d-db29-43be-b0b1-3518945c378f" alt="solar_system_dev_navigation.mp4" /></a>

![Sun glow with lens flare and planet labels](https://cursor.com/artifacts/c/art-6691aeac-65a8-4ab7-bed5-2e6e8172ce0f)
![3D scene with planet label](https://cursor.com/artifacts/c/art-7bde345a-b466-4f10-862c-abf5246a4a9c)

## Known limitation (not a setup bug)
Only 4×4 placeholder low-res DDS textures are committed; the real planet textures and skybox are hosted on a remote server (`https://test.1ink.us/solar-system/`) that is currently unreachable (404/CORS). So planet surfaces and the skybox do not render locally — but the Sun + labels render and camera navigation works, confirming the engine and environment are healthy. Staged planet loading was also confirmed via console logs ("Camera within … Starting download for Jupiter", "Required assets ready … Initializing system"). Details are documented in `AGENTS.md` §16.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75d88d45-1dbd-46c2-8b34-984017d2f7ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75d88d45-1dbd-46c2-8b34-984017d2f7ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

