### PR TITLE
Add main-belt asteroid field with instanced rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ external/
 # Build directories
 build/
 build-web/
+build-test*/
+build-check/
 
 # Emscripten output
 *.wasm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,10 @@ set(SOLARSYSTEM_SOURCES
     src/Solar_System/Earth_System/EarthClouds.h
     src/Solar_System/OrbitLayout.cpp
     src/Solar_System/OrbitLayout.h
+    src/Solar_System/AsteroidOrbit.cpp
+    src/Solar_System/AsteroidOrbit.h
+    src/Solar_System/AsteroidField.cpp
+    src/Solar_System/AsteroidField.h
 )
 
 if(WIN32)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,7 @@ Canonical architecture reference for contributors. For build commands and deploy
 
 The web build adds async resource loading, staged planet initialization, and distance-based texture LOD. The native build loads everything synchronously at startup with full-resolution textures only.
 
-**Graphics features:** atmospheric scattering, PCF/ray-traced shadows, cloud shadows, lens flare, HDR, normal mapping, planetary rings.
+**Graphics features:** atmospheric scattering, PCF/ray-traced shadows, cloud shadows, lens flare, HDR, normal mapping, planetary rings, instanced main-belt asteroid field + comet tails.
 
 ---
 

--- a/resource/shaders/asteroidField.fs
+++ b/resource/shaders/asteroidField.fs
@@ -1,0 +1,25 @@
+#version 300 es
+precision highp float;
+
+in vec3 vFragPos;
+in vec3 vNormal;
+in vec3 vColor;
+
+uniform vec3 lightPos;
+uniform vec3 viewPos;
+uniform float ambientFactor;
+
+out vec4 fragColor;
+
+void main() {
+    vec3 N = normalize(vNormal);
+    vec3 L = normalize(lightPos - vFragPos);
+    float ndotl = max(dot(N, L), 0.0);
+
+    // Soft rim so rocks stay readable against dark space.
+    vec3 V = normalize(viewPos - vFragPos);
+    float rim = pow(1.0 - max(dot(N, V), 0.0), 3.0) * 0.15;
+
+    vec3 lit = vColor * (ambientFactor + ndotl * 0.95 + rim);
+    fragColor = vec4(lit, 1.0);
+}

--- a/resource/shaders/asteroidField.vs
+++ b/resource/shaders/asteroidField.vs
@@ -1,0 +1,26 @@
+#version 300 es
+precision highp float;
+
+layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec3 aNormal;
+layout (location = 2) in mat4 aInstanceMatrix;
+layout (location = 6) in vec4 aInstanceColor;
+
+out vec3 vFragPos;
+out vec3 vNormal;
+out vec3 vColor;
+
+uniform mat4 projection;
+uniform mat4 view;
+uniform float zCoef;
+
+void main() {
+    vec4 worldPos = aInstanceMatrix * vec4(aPos, 1.0);
+    vFragPos = worldPos.xyz;
+    vNormal = mat3(aInstanceMatrix) * aNormal;
+    vColor = aInstanceColor.rgb;
+
+    gl_Position = projection * view * worldPos;
+    gl_Position.z = log2(max(1e-6, gl_Position.w + 1.0)) * zCoef - 1.0;
+    gl_Position.z *= gl_Position.w;
+}

--- a/resource/shaders/cometTail.fs
+++ b/resource/shaders/cometTail.fs
@@ -1,0 +1,19 @@
+#version 300 es
+precision mediump float;
+
+in vec2 vUV;
+in float vFade;
+
+uniform vec3 tailColor;
+uniform float tailOpacity;
+
+out vec4 fragColor;
+
+void main() {
+    // Soft lateral falloff + stronger tip fade.
+    float lateral = 1.0 - abs(vUV.x * 2.0 - 1.0);
+    lateral = smoothstep(0.0, 0.85, lateral);
+    float along = vFade * vFade;
+    float alpha = lateral * along * tailOpacity;
+    fragColor = vec4(tailColor * alpha, alpha);
+}

--- a/resource/shaders/cometTail.vs
+++ b/resource/shaders/cometTail.vs
@@ -1,0 +1,39 @@
+#version 300 es
+precision highp float;
+
+layout (location = 0) in vec2 aCorner;
+layout (location = 1) in vec2 aUV;
+
+out vec2 vUV;
+out float vFade;
+
+uniform mat4 projection;
+uniform mat4 view;
+uniform vec3 nucleusPos;
+uniform vec3 lightPos;
+uniform vec3 cameraRight;
+uniform float tailLength;
+uniform float tailWidth;
+uniform float zCoef;
+
+void main() {
+    vec3 antiSun = nucleusPos - lightPos;
+    float antiLen = length(antiSun);
+    antiSun = (antiLen > 1e-4) ? antiSun / antiLen : vec3(0.0, 0.0, 1.0);
+
+    // Keep the tail billboard readable: width along a screen-stable side axis.
+    vec3 side = cameraRight - antiSun * dot(cameraRight, antiSun);
+    float sideLen = length(side);
+    side = (sideLen > 1e-4) ? side / sideLen : normalize(cross(antiSun, vec3(0.0, 1.0, 0.0)));
+
+    vec3 world = nucleusPos
+               + antiSun * (aUV.y * tailLength)
+               + side * (aCorner.x * tailWidth);
+
+    vUV = aUV;
+    vFade = 1.0 - aUV.y;
+
+    gl_Position = projection * view * vec4(world, 1.0);
+    gl_Position.z = log2(max(1e-6, gl_Position.w + 1.0)) * zCoef - 1.0;
+    gl_Position.z *= gl_Position.w;
+}

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -352,6 +352,7 @@ void Application::RunOneFrame() {
     RenderOrbitPaths();
     RenderStarCorona();
     ProcessSceneComponentsRendering();
+    RenderAsteroidField();
 #ifdef __EMSCRIPTEN__
     RenderPlanetProxyMarkers();
 #endif
@@ -443,6 +444,11 @@ void Application::InitSceneObjects() {
                 FlareSprite{false, 2.75, 2.0, 7}
             }});
     _orbitPathRenderer = make_unique<OrbitPathRenderer>();
+    {
+        const auto asteroidQuality = GetQualitySettings(g_qualityPreset, g_isMobileWeb);
+        _asteroidField = make_unique<AsteroidField>(AsteroidField::kDefaultSeed,
+                                                    asteroidQuality.asteroidInstanceCount);
+    }
 
     InitSongList();
     InitStarSystem();
@@ -751,6 +757,9 @@ void Application::ApplyOrbitScaleMode(int mode) {
     const auto scaleMode = mode == 1 ? OrbitLayout::ScaleMode::Realistic : OrbitLayout::ScaleMode::Compressed;
     OrbitLayout::SetScaleMode(scaleMode);
     RefreshPlanetProxyPositions();
+    if (_asteroidField) {
+        _asteroidField->Update(0.0f); // rebuild instance matrices for new AU→scene mapping
+    }
     std::cout << "[OrbitScale] " << (scaleMode == OrbitLayout::ScaleMode::Realistic ? "realistic" : "compressed")
               << " distances active" << std::endl;
 }
@@ -792,6 +801,20 @@ void Application::RenderOrbitPaths() const {
 
     glDepthMask(GL_TRUE);
     glDisable(GL_BLEND);
+}
+
+void Application::RenderAsteroidField() {
+    if (!_asteroidField || !_sun) {
+        return;
+    }
+
+    _asteroidField->Update(gSimDeltaSeconds);
+
+    static const float zCoef = static_cast<float>(2.0 / glm::log2(_camera.GetFar() + 1.0));
+    _asteroidField->Render(_cameraProjection, _cameraView,
+                           _sun->GetPosition(), _camera.GetPosition(),
+                           _camera.GetRightVector(), _camera.GetUpVector(),
+                           zCoef);
 }
 
 void Application::FocusPlanetByIndex(int idx) {
@@ -1148,6 +1171,9 @@ void Application::ApplyQualityPreset(int preset) {
     }
 
     ApplyRenderResources(settings.shadowResolution, settings.enableHdr);
+    if (_asteroidField) {
+        _asteroidField->SetInstanceCount(settings.asteroidInstanceCount);
+    }
     LogQualityTier(settings, _hdrEnabled, gShadowQuality);
 }
 

--- a/src/Application.h
+++ b/src/Application.h
@@ -3,6 +3,7 @@
 #include "ApplicationTypes.h"
 #include "Auxiliary_Modules/AuxiliaryModules.h"
 #include "PlanetSystemManifest.h"
+#include "Solar_System/AsteroidField.h"
 #include "Solar_System/SolarSystem.h"
 #include "SystemModules.h"
 #include <atomic>
@@ -107,6 +108,7 @@ private:
     std::unique_ptr<Shader> _hdrShader, _lensFlareShader, _starGlowShader;
     std::unique_ptr<LensFlare> _lensFlare;
     std::unique_ptr<OrbitPathRenderer> _orbitPathRenderer;
+    std::unique_ptr<AsteroidField> _asteroidField;
     std::shared_ptr<Star> _sun;
     std::vector<RenderableSceneComponent> _renderableSceneComponents;
     std::vector<std::string> _backgroundSongPaths;
@@ -148,6 +150,7 @@ private:
     void UpdateLOD();             // Central LOD manager: upgrade textures for nearest planets (WASM)
     void RenderPlanetProxyMarkers() const; // Show orbital markers for unloaded planets (WASM)
     void RenderOrbitPaths() const;
+    void RenderAsteroidField();
     void StartSearchNearestPlanet();
     void UpdateSearchNearestPlanet(); // For Emscripten frame-based search
     void StartPlayBackgroundMusic();

--- a/src/QualitySettings.cpp
+++ b/src/QualitySettings.cpp
@@ -21,15 +21,15 @@ std::string GetTexturePath(const std::string& lowRes, const std::string& highRes
 QualityTierSettings GetQualitySettings(int preset, bool mobile) {
     if (mobile) {
         switch (preset) {
-            case 0: return {1024, 0, 0, false, "low"};
-            case 1: return {2048, 2, 0, true, "medium"};
-            default: return {3000, 2, 0, true, "full"};
+            case 0: return {1024, 0, 0, false, 400, "low"};
+            case 1: return {2048, 2, 0, true, 900, "medium"};
+            default: return {3000, 2, 0, true, 1400, "full"};
         }
     }
     switch (preset) {
-        case 0: return {1024, 0, 0, false, "low"};
-        case 1: return {2048, 2, 0, true, "medium"};
-        default: return {3000, 4, 4, true, "full"};
+        case 0: return {1024, 0, 0, false, 600, "low"};
+        case 1: return {2048, 2, 0, true, 1800, "medium"};
+        default: return {3000, 4, 4, true, 4000, "full"};
     }
 }
 
@@ -45,6 +45,7 @@ void LogQualityTier(const QualityTierSettings& settings, bool hdrEnabled, int sh
               << " | high-res concurrency=" << settings.maxConcurrentTextureLoads
               << " | LOD distance multiplier=" << (std::strcmp(settings.name, "medium") == 0 ? 1.5f : 1.0f)
               << " | MSAA=" << settings.requestedMsaaSamples << "x"
+              << " | asteroids=" << settings.asteroidInstanceCount
               << std::defaultfloat << std::endl;
 #ifdef __EMSCRIPTEN__
     std::cout << "[Quality] WebGL MSAA is fixed when the context is created; reload with ?quality="

--- a/src/QualitySettings.h
+++ b/src/QualitySettings.h
@@ -12,6 +12,7 @@ struct QualityTierSettings {
     int maxConcurrentTextureLoads;
     int requestedMsaaSamples;
     bool enableHdr;
+    int asteroidInstanceCount;
     const char* name;
 };
 

--- a/src/Solar_System/AsteroidField.cpp
+++ b/src/Solar_System/AsteroidField.cpp
@@ -1,0 +1,351 @@
+#include "AsteroidField.h"
+
+#include "OrbitLayout.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <glm/gtc/matrix_transform.hpp>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace {
+
+constexpr float kTwoPi = static_cast<float>(2.0 * M_PI);
+
+class Rng {
+public:
+    explicit Rng(uint32_t seed) : _state(seed ? seed : 1u) {}
+
+    uint32_t NextU32() {
+        _state = _state * 1664525u + 1013904223u;
+        return _state;
+    }
+
+    float Next01() {
+        return static_cast<float>((NextU32() >> 8) & 0xFFFFFFu) / static_cast<float>(0x1000000u);
+    }
+
+    float NextRange(float lo, float hi) {
+        return lo + (hi - lo) * Next01();
+    }
+
+private:
+    uint32_t _state;
+};
+
+} // namespace
+
+AsteroidField::AsteroidField(uint32_t seed, int instanceCount)
+    : _seed(seed)
+{
+    // Always generate the full pool so quality presets can raise the draw count later.
+    _asteroids = AsteroidOrbit::GenerateBelt(seed, kMaxInstances);
+    _comets = AsteroidOrbit::GenerateComets();
+    _activeCount = std::clamp(instanceCount, 0, static_cast<int>(_asteroids.size()));
+    _instanceData.resize(static_cast<size_t>(kMaxInstances));
+
+    InitRockMesh();
+    InitInstanceBuffer();
+    InitCometTailMesh();
+    InitShaders();
+    RebuildInstanceBuffer();
+    UploadInstances();
+
+    std::cout << "[AsteroidField] seed=0x" << std::hex << seed << std::dec
+              << " asteroids=" << _activeCount << "/" << _asteroids.size()
+              << " comets=" << _comets.size() << std::endl;
+}
+
+AsteroidField::~AsteroidField() {
+    if (_instanceVbo) {
+        glDeleteBuffers(1, &_instanceVbo);
+    }
+    if (_rockEbo) {
+        glDeleteBuffers(1, &_rockEbo);
+    }
+    if (_rockVbo) {
+        glDeleteBuffers(1, &_rockVbo);
+    }
+    if (_rockVao) {
+        glDeleteVertexArrays(1, &_rockVao);
+    }
+    if (_tailVbo) {
+        glDeleteBuffers(1, &_tailVbo);
+    }
+    if (_tailVao) {
+        glDeleteVertexArrays(1, &_tailVao);
+    }
+}
+
+void AsteroidField::SetInstanceCount(int count) {
+    count = std::clamp(count, 0, static_cast<int>(_asteroids.size()));
+    if (count == _activeCount) {
+        return;
+    }
+    _activeCount = count;
+    RebuildInstanceBuffer();
+    UploadInstances();
+}
+
+void AsteroidField::InitRockMesh() {
+    struct Vert {
+        glm::vec3 p;
+        glm::vec3 n;
+    };
+
+    const glm::vec3 corners[6] = {
+        {0, 1, 0}, {0, -1, 0}, {1, 0, 0}, {-1, 0, 0}, {0, 0, 1}, {0, 0, -1}
+    };
+    const int faces[8][3] = {
+        {0, 2, 4}, {0, 4, 3}, {0, 3, 5}, {0, 5, 2},
+        {1, 4, 2}, {1, 3, 4}, {1, 5, 3}, {1, 2, 5}
+    };
+
+    Rng rng(_seed ^ 0x5F3759DFu);
+    std::vector<Vert> verts;
+    std::vector<unsigned int> indices;
+    verts.reserve(24);
+    indices.reserve(24);
+
+    for (const auto& face : faces) {
+        glm::vec3 tri[3];
+        for (int k = 0; k < 3; ++k) {
+            glm::vec3 p = corners[face[k]];
+            p += glm::vec3(rng.NextRange(-0.18f, 0.18f),
+                           rng.NextRange(-0.18f, 0.18f),
+                           rng.NextRange(-0.18f, 0.18f));
+            p = glm::normalize(p) * rng.NextRange(0.75f, 1.15f);
+            tri[k] = p;
+        }
+        const glm::vec3 n = glm::normalize(glm::cross(tri[1] - tri[0], tri[2] - tri[0]));
+        const unsigned int base = static_cast<unsigned int>(verts.size());
+        for (int k = 0; k < 3; ++k) {
+            verts.push_back({tri[k], n});
+            indices.push_back(base + static_cast<unsigned int>(k));
+        }
+    }
+
+    _rockIndexCount = static_cast<GLsizei>(indices.size());
+
+    struct Packed {
+        float px, py, pz;
+        float nx, ny, nz;
+    };
+    std::vector<Packed> packed(verts.size());
+    for (size_t i = 0; i < verts.size(); ++i) {
+        packed[i] = {verts[i].p.x, verts[i].p.y, verts[i].p.z,
+                     verts[i].n.x, verts[i].n.y, verts[i].n.z};
+    }
+
+    glGenVertexArrays(1, &_rockVao);
+    glGenBuffers(1, &_rockVbo);
+    glGenBuffers(1, &_rockEbo);
+    glBindVertexArray(_rockVao);
+
+    glBindBuffer(GL_ARRAY_BUFFER, _rockVbo);
+    glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(packed.size() * sizeof(Packed)),
+                 packed.data(), GL_STATIC_DRAW);
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, _rockEbo);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, static_cast<GLsizeiptr>(indices.size() * sizeof(unsigned int)),
+                 indices.data(), GL_STATIC_DRAW);
+
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Packed), reinterpret_cast<void*>(0));
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Packed),
+                          reinterpret_cast<void*>(offsetof(Packed, nx)));
+
+    glBindVertexArray(0);
+}
+
+void AsteroidField::InitInstanceBuffer() {
+    glGenBuffers(1, &_instanceVbo);
+    glBindVertexArray(_rockVao);
+    glBindBuffer(GL_ARRAY_BUFFER, _instanceVbo);
+    glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(kMaxInstances * sizeof(InstanceGPU)),
+                 nullptr, GL_DYNAMIC_DRAW);
+
+    const GLsizei stride = static_cast<GLsizei>(sizeof(InstanceGPU));
+    for (int i = 0; i < 4; ++i) {
+        glEnableVertexAttribArray(2 + i);
+        glVertexAttribPointer(2 + i, 4, GL_FLOAT, GL_FALSE, stride,
+                              reinterpret_cast<void*>(sizeof(float) * 4 * i));
+        glVertexAttribDivisor(2 + i, 1);
+    }
+    glEnableVertexAttribArray(6);
+    glVertexAttribPointer(6, 4, GL_FLOAT, GL_FALSE, stride,
+                          reinterpret_cast<void*>(offsetof(InstanceGPU, color)));
+    glVertexAttribDivisor(6, 1);
+
+    glBindVertexArray(0);
+}
+
+void AsteroidField::InitCometTailMesh() {
+    const float quad[] = {
+        -0.5f, 0.0f, 0.0f, 0.0f,
+         0.5f, 0.0f, 1.0f, 0.0f,
+         0.5f, 1.0f, 1.0f, 1.0f,
+        -0.5f, 0.0f, 0.0f, 0.0f,
+         0.5f, 1.0f, 1.0f, 1.0f,
+        -0.5f, 1.0f, 0.0f, 1.0f,
+    };
+
+    glGenVertexArrays(1, &_tailVao);
+    glGenBuffers(1, &_tailVbo);
+    glBindVertexArray(_tailVao);
+    glBindBuffer(GL_ARRAY_BUFFER, _tailVbo);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(quad), quad, GL_STATIC_DRAW);
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), reinterpret_cast<void*>(0));
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float),
+                          reinterpret_cast<void*>(2 * sizeof(float)));
+    glBindVertexArray(0);
+}
+
+void AsteroidField::InitShaders() {
+    _asteroidShader = std::make_unique<Shader>("resource/shaders/asteroidField.vs",
+                                               "resource/shaders/asteroidField.fs");
+    _cometTailShader = std::make_unique<Shader>("resource/shaders/cometTail.vs",
+                                                "resource/shaders/cometTail.fs");
+}
+
+void AsteroidField::RebuildInstanceBuffer() {
+    for (int i = 0; i < _activeCount; ++i) {
+        const OrbitalElements& el = _asteroids[static_cast<size_t>(i)];
+        const glm::vec3 pos = AsteroidOrbit::HeliocentricPosition(el);
+        glm::mat4 model(1.0f);
+        model = glm::translate(model, pos);
+        model = glm::rotate(model, el.spinPhaseRad, glm::vec3(0.3f, 1.0f, 0.2f));
+        model = glm::scale(model, glm::vec3(el.visualRadius));
+        _instanceData[static_cast<size_t>(i)].model = model;
+        _instanceData[static_cast<size_t>(i)].color = glm::vec4(el.color, 1.0f);
+    }
+}
+
+void AsteroidField::UploadInstances() const {
+    if (_instanceVbo == 0 || _activeCount <= 0) {
+        return;
+    }
+    glBindBuffer(GL_ARRAY_BUFFER, _instanceVbo);
+    glBufferSubData(GL_ARRAY_BUFFER, 0,
+                    static_cast<GLsizeiptr>(static_cast<size_t>(_activeCount) * sizeof(InstanceGPU)),
+                    _instanceData.data());
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+void AsteroidField::Update(float simDeltaSeconds) {
+    if (simDeltaSeconds != 0.0f) {
+        for (auto& el : _asteroids) {
+            el.meanAnomalyRad = std::fmod(el.meanAnomalyRad + el.meanMotionRadPerSec * simDeltaSeconds, kTwoPi);
+            el.spinPhaseRad = std::fmod(el.spinPhaseRad + el.spinRateRadPerSec * simDeltaSeconds, kTwoPi);
+        }
+        for (auto& el : _comets) {
+            el.meanAnomalyRad = std::fmod(el.meanAnomalyRad + el.meanMotionRadPerSec * simDeltaSeconds, kTwoPi);
+            el.spinPhaseRad = std::fmod(el.spinPhaseRad + el.spinRateRadPerSec * simDeltaSeconds, kTwoPi);
+        }
+    }
+
+    RebuildInstanceBuffer();
+    UploadInstances();
+}
+
+void AsteroidField::Render(const glm::mat4& projection, const glm::mat4& view,
+                           const glm::vec3& sunPos, const glm::vec3& viewPos,
+                           const glm::vec3& cameraRight, const glm::vec3& /*cameraUp*/,
+                           float zCoef) const {
+    if (!_asteroidShader || _rockVao == 0) {
+        return;
+    }
+
+    glEnable(GL_DEPTH_TEST);
+    glDepthMask(GL_TRUE);
+    glDisable(GL_BLEND);
+    glEnable(GL_CULL_FACE);
+    glCullFace(GL_BACK);
+
+    _asteroidShader->Use();
+    _asteroidShader->SetMat4("projection", projection);
+    _asteroidShader->SetMat4("view", view);
+    _asteroidShader->SetVec3("lightPos", sunPos);
+    _asteroidShader->SetVec3("viewPos", viewPos);
+    _asteroidShader->SetFloat("zCoef", zCoef);
+    _asteroidShader->SetFloat("ambientFactor", 0.12f);
+
+    if (_activeCount > 0) {
+        glBindVertexArray(_rockVao);
+        glDrawElementsInstanced(GL_TRIANGLES, _rockIndexCount, GL_UNSIGNED_INT, nullptr, _activeCount);
+        glBindVertexArray(0);
+    }
+
+    for (const auto& comet : _comets) {
+        const glm::vec3 pos = AsteroidOrbit::HeliocentricPosition(comet);
+        glm::mat4 model(1.0f);
+        model = glm::translate(model, pos);
+        model = glm::rotate(model, comet.spinPhaseRad, glm::vec3(0.2f, 1.0f, 0.1f));
+        model = glm::scale(model, glm::vec3(comet.visualRadius));
+
+        InstanceGPU one{model, glm::vec4(comet.color, 1.0f)};
+        glBindBuffer(GL_ARRAY_BUFFER, _instanceVbo);
+        glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(InstanceGPU), &one);
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+        glBindVertexArray(_rockVao);
+        glDrawElementsInstanced(GL_TRIANGLES, _rockIndexCount, GL_UNSIGNED_INT, nullptr, 1);
+        glBindVertexArray(0);
+    }
+
+    if (_activeCount > 0) {
+        UploadInstances();
+    }
+
+    if (_cometTailShader && _tailVao != 0 && !_comets.empty()) {
+        glDepthMask(GL_FALSE);
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_ONE, GL_ONE);
+        glDisable(GL_CULL_FACE);
+
+        _cometTailShader->Use();
+        _cometTailShader->SetMat4("projection", projection);
+        _cometTailShader->SetMat4("view", view);
+        _cometTailShader->SetVec3("lightPos", sunPos);
+        _cometTailShader->SetVec3("cameraRight", cameraRight);
+        _cometTailShader->SetFloat("zCoef", zCoef);
+
+        glBindVertexArray(_tailVao);
+        for (const auto& comet : _comets) {
+            const glm::vec3 pos = AsteroidOrbit::HeliocentricPosition(comet);
+            const float e = std::clamp(comet.eccentricity, 0.0f, 0.999f);
+            const float rAuExact = AsteroidOrbit::CurrentRadiusAu(comet);
+            const float peri = comet.semiMajorAu * (1.0f - e);
+            const float apo = comet.semiMajorAu * (1.0f + e);
+            const float span = std::max(apo - peri, 0.05f);
+            const float perihelionFactor = std::clamp(1.0f - (rAuExact - peri) / (span * 0.35f), 0.0f, 1.0f);
+
+            if (perihelionFactor < 0.02f) {
+                continue;
+            }
+
+            const float tailLength = (8.0f + comet.visualRadius * 12.0f) * perihelionFactor * perihelionFactor;
+            const float tailWidth = (1.2f + comet.visualRadius) * (0.35f + 0.65f * perihelionFactor);
+
+            _cometTailShader->SetVec3("nucleusPos", pos);
+            _cometTailShader->SetVec3("tailColor", comet.color);
+            _cometTailShader->SetFloat("tailLength", tailLength);
+            _cometTailShader->SetFloat("tailWidth", tailWidth);
+            _cometTailShader->SetFloat("tailOpacity", 0.55f * perihelionFactor);
+
+            glDrawArrays(GL_TRIANGLES, 0, 6);
+        }
+        glBindVertexArray(0);
+
+        glDepthMask(GL_TRUE);
+        glDisable(GL_BLEND);
+        glEnable(GL_CULL_FACE);
+    }
+}

--- a/src/Solar_System/AsteroidField.h
+++ b/src/Solar_System/AsteroidField.h
@@ -2,7 +2,7 @@
 #define SOLARSYSTEM_ASTEROIDFIELD_H
 
 #include "AsteroidOrbit.h"
-#include "Auxiliary_Modules/Shader.h"
+#include "../Auxiliary_Modules/Shader.h"
 #include <glm/glm.hpp>
 #include <memory>
 #include <vector>

--- a/src/Solar_System/AsteroidField.h
+++ b/src/Solar_System/AsteroidField.h
@@ -1,0 +1,80 @@
+#ifndef SOLARSYSTEM_ASTEROIDFIELD_H
+#define SOLARSYSTEM_ASTEROIDFIELD_H
+
+#include "AsteroidOrbit.h"
+#include "Auxiliary_Modules/Shader.h"
+#include <glm/glm.hpp>
+#include <memory>
+#include <vector>
+
+/**
+ * Procedural main-belt asteroid field + a few named comets.
+ * Asteroids are drawn with a single glDrawElementsInstanced call.
+ * Comet nuclei share the rock mesh; tails are additive billboards.
+ */
+class AsteroidField {
+public:
+    static constexpr uint32_t kDefaultSeed = AsteroidOrbit::kDefaultSeed;
+    static constexpr int kMaxInstances = AsteroidOrbit::kMaxInstances;
+    static constexpr int kCometCount = AsteroidOrbit::kCometCount;
+
+    using OrbitalElements = AsteroidOrbit::OrbitalElements;
+
+    explicit AsteroidField(uint32_t seed = kDefaultSeed, int instanceCount = 1800);
+    ~AsteroidField();
+
+    AsteroidField(const AsteroidField&) = delete;
+    AsteroidField& operator=(const AsteroidField&) = delete;
+
+    void SetInstanceCount(int count);
+    int GetActiveInstanceCount() const { return _activeCount; }
+    int GetGeneratedCount() const { return static_cast<int>(_asteroids.size()); }
+
+    /** Advance mean anomalies / spin; rebuild instance matrices. */
+    void Update(float simDeltaSeconds);
+
+    /**
+     * Draw belt (one instanced call) then comet nuclei + tails.
+     * No self-shadowing — depth writes enabled for rock meshes only.
+     */
+    void Render(const glm::mat4& projection, const glm::mat4& view,
+                const glm::vec3& sunPos, const glm::vec3& viewPos,
+                const glm::vec3& cameraRight, const glm::vec3& cameraUp,
+                float zCoef) const;
+
+    const std::vector<OrbitalElements>& GetAsteroids() const { return _asteroids; }
+    const std::vector<OrbitalElements>& GetComets() const { return _comets; }
+
+private:
+    struct InstanceGPU {
+        glm::mat4 model;
+        glm::vec4 color;
+    };
+
+    void InitRockMesh();
+    void InitInstanceBuffer();
+    void InitCometTailMesh();
+    void InitShaders();
+    void RebuildInstanceBuffer();
+    void UploadInstances() const;
+
+    uint32_t _seed = kDefaultSeed;
+    int _activeCount = 0;
+    std::vector<OrbitalElements> _asteroids;
+    std::vector<OrbitalElements> _comets;
+    std::vector<InstanceGPU> _instanceData;
+
+    GLuint _rockVao = 0;
+    GLuint _rockVbo = 0;
+    GLuint _rockEbo = 0;
+    GLuint _instanceVbo = 0;
+    GLsizei _rockIndexCount = 0;
+
+    GLuint _tailVao = 0;
+    GLuint _tailVbo = 0;
+
+    std::unique_ptr<Shader> _asteroidShader;
+    std::unique_ptr<Shader> _cometTailShader;
+};
+
+#endif // SOLARSYSTEM_ASTEROIDFIELD_H

--- a/src/Solar_System/AsteroidOrbit.cpp
+++ b/src/Solar_System/AsteroidOrbit.cpp
@@ -1,0 +1,163 @@
+#include "AsteroidOrbit.h"
+
+#include "OrbitLayout.h"
+
+#include <algorithm>
+#include <cmath>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+namespace AsteroidOrbit {
+namespace {
+
+constexpr float kTwoPi = static_cast<float>(2.0 * M_PI);
+
+class Rng {
+public:
+    explicit Rng(uint32_t seed) : _state(seed ? seed : 1u) {}
+
+    uint32_t NextU32() {
+        _state = _state * 1664525u + 1013904223u;
+        return _state;
+    }
+
+    float Next01() {
+        return static_cast<float>((NextU32() >> 8) & 0xFFFFFFu) / static_cast<float>(0x1000000u);
+    }
+
+    float NextRange(float lo, float hi) {
+        return lo + (hi - lo) * Next01();
+    }
+
+private:
+    uint32_t _state;
+};
+
+float DegToRad(float deg) {
+    return deg * static_cast<float>(M_PI / 180.0);
+}
+
+} // namespace
+
+const CometDef* GetCometDefs() {
+    static const CometDef kDefs[kCometCount] = {
+        {"1P/Halley", 0.586f, 0.967f, 162.3f, 111.3f, 58.4f, 38.4f, 75.3f, 1.8f, {0.75f, 0.82f, 0.95f}},
+        {"2P/Encke", 0.336f, 0.848f, 11.8f, 186.5f, 334.6f, 120.0f, 3.3f, 1.2f, {0.85f, 0.78f, 0.65f}},
+        {"C/1995 O1 Hale-Bopp", 0.914f, 0.995f, 89.4f, 130.6f, 282.5f, 210.0f, 2530.0f, 2.2f, {0.70f, 0.88f, 1.0f}},
+    };
+    return kDefs;
+}
+
+std::vector<OrbitalElements> GenerateBelt(uint32_t seed, int count) {
+    count = std::clamp(count, 0, kMaxInstances);
+    std::vector<OrbitalElements> out;
+    out.reserve(static_cast<size_t>(count));
+
+    Rng rng(seed);
+    for (int i = 0; i < count; ++i) {
+        OrbitalElements el;
+        el.semiMajorAu = rng.NextRange(OrbitLayout::kMainBeltInnerAu, OrbitLayout::kMainBeltOuterAu);
+        el.eccentricity = rng.NextRange(0.01f, 0.22f);
+        el.inclinationRad = DegToRad(rng.NextRange(0.2f, 18.0f));
+        el.argPeriapsisRad = rng.NextRange(0.0f, kTwoPi);
+        el.longAscNodeRad = rng.NextRange(0.0f, kTwoPi);
+        el.meanAnomalyRad = rng.NextRange(0.0f, kTwoPi);
+
+        const float periodYears = std::pow(el.semiMajorAu, 1.5f);
+        const float periodSeconds = OrbitLayout::kEarthOrbitSecondsAt1x * periodYears;
+        el.meanMotionRadPerSec = kTwoPi / std::max(periodSeconds, 1.0f);
+
+        const float sizeRoll = rng.Next01();
+        el.visualRadius = (sizeRoll > 0.97f) ? rng.NextRange(1.2f, 2.4f)
+                         : (sizeRoll > 0.85f) ? rng.NextRange(0.6f, 1.2f)
+                                              : rng.NextRange(0.15f, 0.55f);
+        el.spinPhaseRad = rng.NextRange(0.0f, kTwoPi);
+        el.spinRateRadPerSec = rng.NextRange(-1.5f, 1.5f);
+
+        const float shade = rng.NextRange(0.35f, 0.70f);
+        const float tint = rng.NextRange(-0.05f, 0.08f);
+        el.color = glm::vec3(shade + tint * 0.4f, shade + tint * 0.15f, shade - tint * 0.25f);
+
+        out.push_back(el);
+    }
+    return out;
+}
+
+std::vector<OrbitalElements> GenerateComets() {
+    std::vector<OrbitalElements> out;
+    out.reserve(kCometCount);
+    const CometDef* defs = GetCometDefs();
+    for (int i = 0; i < kCometCount; ++i) {
+        const CometDef& d = defs[i];
+        OrbitalElements el;
+        el.eccentricity = std::clamp(d.eccentricity, 0.0f, 0.999f);
+        el.semiMajorAu = d.perihelionAu / std::max(1.0f - el.eccentricity, 1e-4f);
+        el.inclinationRad = DegToRad(d.inclinationDeg);
+        el.argPeriapsisRad = DegToRad(d.argPeriapsisDeg);
+        el.longAscNodeRad = DegToRad(d.longAscNodeDeg);
+        el.meanAnomalyRad = DegToRad(d.meanAnomaly0Deg);
+        const float periodSeconds = OrbitLayout::kEarthOrbitSecondsAt1x * std::max(d.periodYears, 0.1f);
+        el.meanMotionRadPerSec = kTwoPi / periodSeconds;
+        el.visualRadius = d.nucleusRadius;
+        el.spinPhaseRad = 0.0f;
+        el.spinRateRadPerSec = 0.4f;
+        el.color = d.color;
+        out.push_back(el);
+    }
+    return out;
+}
+
+float SolveKepler(float meanAnomaly, float eccentricity) {
+    float m = std::fmod(meanAnomaly, kTwoPi);
+    if (m < 0.0f) {
+        m += kTwoPi;
+    }
+    if (m > static_cast<float>(M_PI)) {
+        m -= kTwoPi;
+    }
+
+    float eAnom = m;
+    for (int i = 0; i < 8; ++i) {
+        const float f = eAnom - eccentricity * std::sin(eAnom) - m;
+        const float fp = 1.0f - eccentricity * std::cos(eAnom);
+        eAnom -= f / fp;
+    }
+    return eAnom;
+}
+
+glm::vec3 OrbitalToCartesian(float radius, float trueAnomaly,
+                             float inclination, float argPeriapsis, float longAscNode) {
+    const float u = argPeriapsis + trueAnomaly;
+    const float cosO = std::cos(longAscNode);
+    const float sinO = std::sin(longAscNode);
+    const float cosI = std::cos(inclination);
+    const float sinI = std::sin(inclination);
+    const float cosU = std::cos(u);
+    const float sinU = std::sin(u);
+
+    const float x = radius * (cosO * cosU - sinO * sinU * cosI);
+    const float yEcl = radius * (sinO * cosU + cosO * sinU * cosI);
+    const float zEcl = radius * (sinU * sinI);
+    return glm::vec3(x, zEcl, yEcl);
+}
+
+float CurrentRadiusAu(const OrbitalElements& el) {
+    const float e = std::clamp(el.eccentricity, 0.0f, 0.999f);
+    const float eAnom = SolveKepler(el.meanAnomalyRad, e);
+    return el.semiMajorAu * (1.0f - e * std::cos(eAnom));
+}
+
+glm::vec3 HeliocentricPosition(const OrbitalElements& el) {
+    const float e = std::clamp(el.eccentricity, 0.0f, 0.999f);
+    const float eAnom = SolveKepler(el.meanAnomalyRad, e);
+    const float cosE = std::cos(eAnom);
+    const float sinE = std::sin(eAnom);
+    const float trueAnomaly = std::atan2(std::sqrt(1.0f - e * e) * sinE, cosE - e);
+    const float rAu = el.semiMajorAu * (1.0f - e * cosE);
+    const float rScene = OrbitLayout::AuToSceneDistance(rAu);
+    return OrbitalToCartesian(rScene, trueAnomaly, el.inclinationRad, el.argPeriapsisRad, el.longAscNodeRad);
+}
+
+} // namespace AsteroidOrbit

--- a/src/Solar_System/AsteroidOrbit.h
+++ b/src/Solar_System/AsteroidOrbit.h
@@ -1,0 +1,55 @@
+#ifndef SOLARSYSTEM_ASTEROIDORBIT_H
+#define SOLARSYSTEM_ASTEROIDORBIT_H
+
+#include <glm/glm.hpp>
+#include <cstdint>
+#include <vector>
+
+/** Keplerian helpers shared by AsteroidField and unit tests (no GL). */
+namespace AsteroidOrbit {
+
+constexpr uint32_t kDefaultSeed = 0xA57E201Du;
+constexpr int kMaxInstances = 4096;
+constexpr int kCometCount = 3;
+
+struct OrbitalElements {
+    float semiMajorAu = 2.5f;
+    float eccentricity = 0.05f;
+    float inclinationRad = 0.0f;
+    float argPeriapsisRad = 0.0f;
+    float longAscNodeRad = 0.0f;
+    float meanAnomalyRad = 0.0f;
+    float meanMotionRadPerSec = 0.0f;
+    float visualRadius = 0.4f;
+    float spinPhaseRad = 0.0f;
+    float spinRateRadPerSec = 0.2f;
+    glm::vec3 color{0.55f, 0.50f, 0.45f};
+};
+
+struct CometDef {
+    const char* name;
+    float perihelionAu;
+    float eccentricity;
+    float inclinationDeg;
+    float argPeriapsisDeg;
+    float longAscNodeDeg;
+    float meanAnomaly0Deg;
+    float periodYears;
+    float nucleusRadius;
+    glm::vec3 color;
+};
+
+const CometDef* GetCometDefs();
+
+std::vector<OrbitalElements> GenerateBelt(uint32_t seed, int count);
+std::vector<OrbitalElements> GenerateComets();
+
+float SolveKepler(float meanAnomaly, float eccentricity);
+glm::vec3 OrbitalToCartesian(float radius, float trueAnomaly,
+                             float inclination, float argPeriapsis, float longAscNode);
+glm::vec3 HeliocentricPosition(const OrbitalElements& el);
+float CurrentRadiusAu(const OrbitalElements& el);
+
+} // namespace AsteroidOrbit
+
+#endif // SOLARSYSTEM_ASTEROIDORBIT_H

--- a/src/Solar_System/OrbitLayout.cpp
+++ b/src/Solar_System/OrbitLayout.cpp
@@ -18,7 +18,6 @@ struct BodyData {
     float siderealRotationDays; // negative => retrograde
 };
 
-constexpr float kAuToSceneUnits = 1900.0f; // 1 AU ≈ Earth's compressed orbit radius
 constexpr float kEarthYearDays = 365.25f;
 
 // NASA fact-sheet averages for periods/inclination/sidereal day.
@@ -129,6 +128,46 @@ float GetAuDistance(Body body) {
     return kBodies[bodyIndex(body)].auDistance;
 }
 
+float AuToSceneDistance(float au) {
+    if (au <= 0.0f) {
+        return 0.0f;
+    }
+    if (g_scaleMode == ScaleMode::Realistic) {
+        return au * kAuToSceneUnits;
+    }
+
+    // Piecewise-linear remap through planet compressed orbit radii so the
+    // main belt (and comets) sit between Mars and Jupiter in art scale.
+    struct Key {
+        float au;
+        float scene;
+    };
+    const Key keys[] = {
+        {GetAuDistance(Body::Mercury), glm::length(GetCompressedOffset(Body::Mercury))},
+        {GetAuDistance(Body::Venus), glm::length(GetCompressedOffset(Body::Venus))},
+        {GetAuDistance(Body::Earth), glm::length(GetCompressedOffset(Body::Earth))},
+        {GetAuDistance(Body::Mars), glm::length(GetCompressedOffset(Body::Mars))},
+        {GetAuDistance(Body::Jupiter), glm::length(GetCompressedOffset(Body::Jupiter))},
+        {GetAuDistance(Body::Saturn), glm::length(GetCompressedOffset(Body::Saturn))},
+        {GetAuDistance(Body::Uranus), glm::length(GetCompressedOffset(Body::Uranus))},
+        {GetAuDistance(Body::Neptune), glm::length(GetCompressedOffset(Body::Neptune))},
+        {GetAuDistance(Body::Pluto), glm::length(GetCompressedOffset(Body::Pluto))},
+    };
+    constexpr int keyCount = static_cast<int>(sizeof(keys) / sizeof(keys[0]));
+
+    if (au <= keys[0].au) {
+        return keys[0].scene * (au / keys[0].au);
+    }
+    for (int i = 0; i < keyCount - 1; ++i) {
+        if (au <= keys[i + 1].au) {
+            const float t = (au - keys[i].au) / (keys[i + 1].au - keys[i].au);
+            return keys[i].scene + t * (keys[i + 1].scene - keys[i].scene);
+        }
+    }
+    const Key& last = keys[keyCount - 1];
+    return last.scene * (au / last.au);
+}
+
 float GetOrbitalPeriodDays(Body body) {
     return kBodies[bodyIndex(body)].orbitalPeriodDays;
 }
@@ -145,7 +184,7 @@ float GetOrbitRadius(Body body) {
     if (g_scaleMode == ScaleMode::Compressed) {
         return glm::length(compressed);
     }
-    return GetAuDistance(body) * kAuToSceneUnits;
+    return AuToSceneDistance(GetAuDistance(body));
 }
 
 float GetSceneDistance(Body body) {

--- a/src/Solar_System/OrbitLayout.cpp
+++ b/src/Solar_System/OrbitLayout.cpp
@@ -1,6 +1,6 @@
 #include "OrbitLayout.h"
 
-#include "Auxiliary_Modules/Ephemeris.h"
+#include "../Auxiliary_Modules/Ephemeris.h"
 
 #include <algorithm>
 #include <cmath>

--- a/src/Solar_System/OrbitLayout.h
+++ b/src/Solar_System/OrbitLayout.h
@@ -28,6 +28,13 @@ enum class ScaleMode : int {
 /** Wall seconds for one Earth orbit at timeScale == 1. */
 constexpr float kEarthOrbitSecondsAt1x = 120.0f;
 
+/** 1 AU in scene units (matches Earth's compressed orbit radius). */
+constexpr float kAuToSceneUnits = 1900.0f;
+
+/** Main-belt semi-major axis range in AU (approximate). */
+constexpr float kMainBeltInnerAu = 2.1f;
+constexpr float kMainBeltOuterAu = 3.3f;
+
 void SetScaleMode(ScaleMode mode);
 ScaleMode GetScaleMode();
 
@@ -50,6 +57,13 @@ glm::vec3 GetOffset(Body body);
 
 /** Semi-major axis in astronomical units (NASA fact-sheet averages). */
 float GetAuDistance(Body body);
+
+/**
+ * Map a heliocentric AU distance to scene units for the active scale mode.
+ * Realistic: au * kAuToSceneUnits.
+ * Compressed: piecewise-linear through planet art orbit radii.
+ */
+float AuToSceneDistance(float au);
 
 /** Orbit radius in scene units (scale-mode aware; independent of anomaly). */
 float GetOrbitRadius(Body body);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ FetchContent_MakeAvailable(googletest)
 
 set(SOLARSYSTEM_TEST_SOURCES
     ${CMAKE_SOURCE_DIR}/src/Solar_System/OrbitLayout.cpp
+    ${CMAKE_SOURCE_DIR}/src/Solar_System/AsteroidOrbit.cpp
     ${CMAKE_SOURCE_DIR}/src/Auxiliary_Modules/Ephemeris.cpp
     ${CMAKE_SOURCE_DIR}/src/QualitySettings.cpp
     ${CMAKE_SOURCE_DIR}/src/Auxiliary_Modules/PlanetManifestLoader.cpp
@@ -25,6 +26,7 @@ add_executable(SolarSystemTests
     test_quality_settings.cpp
     test_planet_manifest_loader.cpp
     test_texture_loading_queue.cpp
+    test_asteroid_field.cpp
     stub_texture_image2d.cpp
     ${SOLARSYSTEM_TEST_SOURCES}
 )

--- a/tests/test_asteroid_field.cpp
+++ b/tests/test_asteroid_field.cpp
@@ -1,0 +1,101 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "Solar_System/AsteroidOrbit.h"
+#include "Solar_System/OrbitLayout.h"
+
+namespace {
+
+bool Near(float a, float b, float eps = 0.05f) {
+    return std::fabs(a - b) <= eps;
+}
+
+} // namespace
+
+class AsteroidOrbitTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        OrbitLayout::ResetForTests();
+    }
+};
+
+TEST_F(AsteroidOrbitTest, GenerateBeltIsDeterministic) {
+    const auto a = AsteroidOrbit::GenerateBelt(AsteroidOrbit::kDefaultSeed, 128);
+    const auto b = AsteroidOrbit::GenerateBelt(AsteroidOrbit::kDefaultSeed, 128);
+    ASSERT_EQ(a.size(), b.size());
+    for (size_t i = 0; i < a.size(); ++i) {
+        EXPECT_FLOAT_EQ(a[i].semiMajorAu, b[i].semiMajorAu);
+        EXPECT_FLOAT_EQ(a[i].meanAnomalyRad, b[i].meanAnomalyRad);
+        EXPECT_FLOAT_EQ(a[i].visualRadius, b[i].visualRadius);
+    }
+}
+
+TEST_F(AsteroidOrbitTest, GenerateBeltRespectsMainBeltAuRange) {
+    const auto belt = AsteroidOrbit::GenerateBelt(42u, 500);
+    ASSERT_EQ(belt.size(), 500u);
+    for (const auto& el : belt) {
+        EXPECT_GE(el.semiMajorAu, OrbitLayout::kMainBeltInnerAu - 1e-4f);
+        EXPECT_LE(el.semiMajorAu, OrbitLayout::kMainBeltOuterAu + 1e-4f);
+        EXPECT_GE(el.eccentricity, 0.0f);
+        EXPECT_LT(el.eccentricity, 0.25f);
+        EXPECT_GT(el.meanMotionRadPerSec, 0.0f);
+    }
+}
+
+TEST_F(AsteroidOrbitTest, GenerateBeltClampsToMaxInstances) {
+    const auto belt = AsteroidOrbit::GenerateBelt(1u, AsteroidOrbit::kMaxInstances + 500);
+    EXPECT_EQ(belt.size(), static_cast<size_t>(AsteroidOrbit::kMaxInstances));
+}
+
+TEST_F(AsteroidOrbitTest, RealisticPositionsSitBetweenMarsAndJupiter) {
+    OrbitLayout::SetScaleMode(OrbitLayout::ScaleMode::Realistic);
+    const float marsR = OrbitLayout::GetOrbitRadius(OrbitLayout::Body::Mars);
+    const float jupiterR = OrbitLayout::GetOrbitRadius(OrbitLayout::Body::Jupiter);
+
+    const auto belt = AsteroidOrbit::GenerateBelt(7u, 64);
+    for (const auto& el : belt) {
+        // Near-circular approximation: scene radius ≈ a mapped through AuToSceneDistance.
+        const float sceneA = OrbitLayout::AuToSceneDistance(el.semiMajorAu);
+        EXPECT_GT(sceneA, marsR);
+        EXPECT_LT(sceneA, jupiterR);
+
+        const glm::vec3 pos = AsteroidOrbit::HeliocentricPosition(el);
+        const float r = glm::length(pos);
+        // Allow eccentricity to pull slightly inside/outside the a-band.
+        EXPECT_GT(r, marsR * 0.75f);
+        EXPECT_LT(r, jupiterR * 1.15f);
+    }
+}
+
+TEST_F(AsteroidOrbitTest, CompressedBeltFitsMarsJupiterArtGap) {
+    OrbitLayout::SetScaleMode(OrbitLayout::ScaleMode::Compressed);
+    const float marsR = OrbitLayout::GetOrbitRadius(OrbitLayout::Body::Mars);
+    const float jupiterR = OrbitLayout::GetOrbitRadius(OrbitLayout::Body::Jupiter);
+
+    const float inner = OrbitLayout::AuToSceneDistance(OrbitLayout::kMainBeltInnerAu);
+    const float outer = OrbitLayout::AuToSceneDistance(OrbitLayout::kMainBeltOuterAu);
+    EXPECT_GT(inner, marsR);
+    EXPECT_LT(outer, jupiterR);
+    EXPECT_GT(outer, inner);
+}
+
+TEST_F(AsteroidOrbitTest, NamedCometsHaveHighEccentricity) {
+    const auto comets = AsteroidOrbit::GenerateComets();
+    ASSERT_EQ(comets.size(), static_cast<size_t>(AsteroidOrbit::kCometCount));
+    for (const auto& c : comets) {
+        EXPECT_GT(c.eccentricity, 0.7f);
+        EXPECT_GT(c.semiMajorAu, 0.0f);
+        EXPECT_GT(c.meanMotionRadPerSec, 0.0f);
+        const float peri = c.semiMajorAu * (1.0f - c.eccentricity);
+        EXPECT_LT(peri, 1.5f);
+    }
+}
+
+TEST_F(AsteroidOrbitTest, KeplerCircularOrbitRadiusMatchesSemiMajor) {
+    AsteroidOrbit::OrbitalElements el;
+    el.semiMajorAu = 2.5f;
+    el.eccentricity = 0.0f;
+    el.meanAnomalyRad = 1.234f;
+    EXPECT_TRUE(Near(AsteroidOrbit::CurrentRadiusAu(el), 2.5f, 1e-4f));
+}

--- a/tests/test_orbit_layout.cpp
+++ b/tests/test_orbit_layout.cpp
@@ -69,11 +69,28 @@ TEST_F(OrbitLayoutTest, RealisticModeScalesOrbitRadius) {
 
     EXPECT_TRUE(Near(OrbitLayout::GetAuDistance(OrbitLayout::Body::Earth), 1.0f));
 
-    const float expectedJupiterRadius = 5.203f * 1900.0f;
+    const float expectedJupiterRadius = 5.203f * OrbitLayout::kAuToSceneUnits;
     EXPECT_TRUE(Near(OrbitLayout::GetOrbitRadius(OrbitLayout::Body::Jupiter), expectedJupiterRadius));
     EXPECT_TRUE(Near(glm::length(OrbitLayout::GetOffset(OrbitLayout::Body::Jupiter)), expectedJupiterRadius, 1.0f));
     EXPECT_GT(OrbitLayout::GetOrbitRadius(OrbitLayout::Body::Jupiter),
               glm::length(OrbitLayout::GetCompressedOffset(OrbitLayout::Body::Jupiter)));
+}
+
+TEST_F(OrbitLayoutTest, AuToSceneDistanceRealisticIsLinear) {
+    OrbitLayout::SetScaleMode(OrbitLayout::ScaleMode::Realistic);
+    EXPECT_TRUE(Near(OrbitLayout::AuToSceneDistance(1.0f), OrbitLayout::kAuToSceneUnits));
+    EXPECT_TRUE(Near(OrbitLayout::AuToSceneDistance(2.5f), 2.5f * OrbitLayout::kAuToSceneUnits));
+}
+
+TEST_F(OrbitLayoutTest, AuToSceneDistanceCompressedPlacesBeltBetweenMarsAndJupiter) {
+    OrbitLayout::SetScaleMode(OrbitLayout::ScaleMode::Compressed);
+    const float marsR = OrbitLayout::GetOrbitRadius(OrbitLayout::Body::Mars);
+    const float jupiterR = OrbitLayout::GetOrbitRadius(OrbitLayout::Body::Jupiter);
+    const float beltInner = OrbitLayout::AuToSceneDistance(OrbitLayout::kMainBeltInnerAu);
+    const float beltOuter = OrbitLayout::AuToSceneDistance(OrbitLayout::kMainBeltOuterAu);
+    EXPECT_GT(beltInner, marsR);
+    EXPECT_LT(beltOuter, jupiterR);
+    EXPECT_GT(beltOuter, beltInner);
 }
 
 TEST_F(OrbitLayoutTest, SunOffsetIsZeroInBothModes) {

--- a/tests/test_quality_settings.cpp
+++ b/tests/test_quality_settings.cpp
@@ -9,28 +9,35 @@ void ExpectTier(const QualityTierSettings& settings,
                 int maxConcurrentTextureLoads,
                 int requestedMsaaSamples,
                 bool enableHdr,
+                int asteroidInstanceCount,
                 const char* name) {
     EXPECT_EQ(settings.shadowResolution, shadowResolution);
     EXPECT_EQ(settings.maxConcurrentTextureLoads, maxConcurrentTextureLoads);
     EXPECT_EQ(settings.requestedMsaaSamples, requestedMsaaSamples);
     EXPECT_EQ(settings.enableHdr, enableHdr);
+    EXPECT_EQ(settings.asteroidInstanceCount, asteroidInstanceCount);
     EXPECT_STREQ(settings.name, name);
 }
 
 } // namespace
 
 TEST(QualitySettingsTest, DesktopPresetMapping) {
-    ExpectTier(GetQualitySettings(0, false), 1024, 0, 0, false, "low");
-    ExpectTier(GetQualitySettings(1, false), 2048, 2, 0, true, "medium");
-    ExpectTier(GetQualitySettings(2, false), 3000, 4, 4, true, "full");
+    ExpectTier(GetQualitySettings(0, false), 1024, 0, 0, false, 600, "low");
+    ExpectTier(GetQualitySettings(1, false), 2048, 2, 0, true, 1800, "medium");
+    ExpectTier(GetQualitySettings(2, false), 3000, 4, 4, true, 4000, "full");
 }
 
 TEST(QualitySettingsTest, MobileDowngradesMsaaOnFullPreset) {
-    ExpectTier(GetQualitySettings(2, true), 3000, 2, 0, true, "full");
+    ExpectTier(GetQualitySettings(2, true), 3000, 2, 0, true, 1400, "full");
+}
+
+TEST(QualitySettingsTest, MobileScalesAsteroidCountsDown) {
+    ExpectTier(GetQualitySettings(0, true), 1024, 0, 0, false, 400, "low");
+    ExpectTier(GetQualitySettings(1, true), 2048, 2, 0, true, 900, "medium");
 }
 
 TEST(QualitySettingsTest, OutOfRangePresetUsesFullTier) {
-    ExpectTier(GetQualitySettings(99, false), 3000, 4, 4, true, "full");
+    ExpectTier(GetQualitySettings(99, false), 3000, 4, 4, true, 4000, "full");
 }
 
 #ifndef __EMSCRIPTEN__


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a procedural main-belt asteroid field between Mars and Jupiter, plus a few named comets with perihelion-scaled tails.

## Changes
- **AsteroidOrbit / AsteroidField**: Seeded Keplerian generation (2.1–3.3 AU), low-poly rock mesh, single `glDrawElementsInstanced` draw for the belt
- **Comets**: Halley, Encke, Hale-Bopp with additive billboard tails that grow near perihelion
- **OrbitLayout::AuToSceneDistance**: Realistic AU→scene mapping; compressed mode piecewise-linear through planet art radii so the belt fits the Mars–Jupiter gap
- **QualitySettings**: New `asteroidInstanceCount` knob (desktop 600/1800/4000, mobile 400/900/1400)
- Unit tests for belt generation, AU mapping, and quality counts (43 tests passing)
- Web (Emscripten) build verified in preview

## Walkthrough
![Asteroid belt between Mars and Jupiter (compressed scale)](https://cursor.com/artifacts/c/art-5872b442-a407-4ced-b774-f02e4907346e)
![Console confirms AsteroidField init at full quality](https://cursor.com/artifacts/c/art-9079ee69-17d8-4057-88f5-69b4c0d674a6)

## Acceptance
- [x] Belt renders between Mars and Jupiter (one instanced draw)
- [x] Instance count respects quality preset
- [x] GLES3/WebGL 2–compatible APIs (`glDrawElementsInstanced` / `glVertexAttribDivisor`); no geometry shaders
- [x] `./build-web.sh` succeeds; preview shows belt at ~2050 scene units in compressed mode

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd5693e5-9a00-4040-9634-ab8841daacf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd5693e5-9a00-4040-9634-ab8841daacf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

