### PR TITLE
Add WebXR immersive-vr Enter VR stereo path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ set(SOLARSYSTEM_SOURCES
     src/Solar_System/AsteroidOrbit.h
     src/Solar_System/AsteroidField.cpp
     src/Solar_System/AsteroidField.h
+    src/XrState.h
 )
 
 if(WIN32)
@@ -228,7 +229,7 @@ if(EMSCRIPTEN)
         "SHELL:--preload-file ${CMAKE_SOURCE_DIR}/resource/textures_low@/resource/textures_low"
         "SHELL:-sMODULARIZE=1"
         "SHELL:-sEXPORT_ES6=1"
-        "SHELL:-sEXPORTED_RUNTIME_METHODS=['ccall','cwrap']"
+        "SHELL:-sEXPORTED_RUNTIME_METHODS=['ccall','cwrap','HEAPF32']"
         "SHELL:-sEXPORTED_FUNCTIONS=['_main']"
     )
 

--- a/docs/plans/TESTING_GUIDE.md
+++ b/docs/plans/TESTING_GUIDE.md
@@ -382,6 +382,8 @@ http://localhost:4173/solar-system/?quality=full
 
 `window.setQualityPreset(0|1|2)` changes LOD, shadow resolution, and queue concurrency at runtime. Reload with the corresponding URL to change MSAA.
 
+**WebXR:** Entering VR forces the **medium** preset (or keeps **low**). Because MSAA is fixed at context creation, launch with `?quality=medium` (or low) before clicking **Enter VR** for the best headset framerate. See [WEBXR_PLAN.md](WEBXR_PLAN.md).
+
 #### Measurable medium-vs-full check
 
 1. Open each URL in a fresh tab and confirm the `[Quality]` console line:

--- a/docs/plans/WEBXR_PLAN.md
+++ b/docs/plans/WEBXR_PLAN.md
@@ -1,0 +1,44 @@
+# WebXR immersive VR (WASM renderer)
+
+Exploratory WebXR path for the C++/Emscripten WebGL 2 app. Companion Three.js notes at the end.
+
+## User-facing behavior
+
+- Settings panel shows **Enter VR** only when `navigator.xr.isSessionSupported('immersive-vr')` is true.
+- Non-XR browsers never see the button; desktop 2-D path is unchanged.
+- Entering VR:
+  1. `gl.makeXRCompatible()` on the existing WebGL 2 context
+  2. `XRWebGLLayer` as `baseLayer`
+  3. Pauses the Emscripten main loop (`emscripten_pause_main_loop`)
+  4. Drives frames with `session.requestAnimationFrame`
+  5. Defaults quality to **medium** (or keeps **low** if already low)
+- Controllers: left stick → `SetTouchMovement`, right stick Y → vertical, right stick X → snap yaw via `AddTouchLook`, left grip → climb.
+- Exit VR resumes the 2-D main loop and restores the previous quality preset.
+
+## C++ stereo path
+
+| Export | Role |
+|--------|------|
+| `SetXrSessionActive` | Toggle XR mode + pause/resume main loop |
+| `SetXrEyeCount` / `SetXrEyeViewport` | Per-eye viewports from `XRWebGLLayer` |
+| `GetXrMatrixScratch` + `CommitXrEyeMatrices` | JS writes view/proj (column-major float16×2) into WASM |
+| `RunXrFrame` | One `RunOneFrame` without `glfwSwapBuffers` / FBO 0 |
+| `GetCameraPositionX/Y/Z` | Fly-camera position for `view * T(-cam)` |
+
+Per XR frame, C++ renders each eye with overridden view/projection (skybox uses the eye projection). Shadow-map passes are **skipped in VR** so they cannot rebind FBO 0 over the XR layer. HDR glow / lens flare are also skipped in VR for the same reason.
+
+## Context creation
+
+`Module.contextAttributes.xrCompatible = true` is set from `web/src/main.ts` before GLFW creates the WebGL 2 context. MSAA is still fixed at context creation — prefer `?quality=medium` (0× MSAA) when targeting VR headsets; see [TESTING_GUIDE.md](TESTING_GUIDE.md) quality table.
+
+## Three.js companion spike
+
+`web/threejs/` can host a faster UX spike via Three's `WebXRManager` / `VRButton` on the **WebGLRenderer fallback** path (WebGPU XR support is still uneven). The WASM path above is the acceptance target for the main solar-system app.
+
+## Manual check
+
+1. Chrome + WebXR emulator **or** a Quest browser on HTTPS/`localhost`.
+2. Open `/solar-system/`, wait for load, confirm **Enter VR** appears.
+3. Enter VR → stereoscopic view, head tracking, stick flight.
+4. Exit VR → 2-D canvas resumes; overlays visible again.
+5. Firefox/Safari without immersive-vr → no button, no console errors beyond a single availability log.

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -9,11 +9,12 @@
 #include <SDL_image.h>
 #include <algorithm>
 #include <array>
-#include <fstream>
-#include <random>
 #include <cstring>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <random>
+#include <glm/gtc/type_ptr.hpp>
 
 using namespace std;
 
@@ -148,6 +149,51 @@ extern "C" {
     }
     EMSCRIPTEN_KEEPALIVE int GetOrbitLines() {
         return activeApplication && activeApplication->GetOrbitLinesEnabled() ? 1 : 0;
+    }
+
+    // --- WebXR stereo control surface ---
+    EMSCRIPTEN_KEEPALIVE void SetXrSessionActive(int active) {
+        if (!activeApplication) {
+            return;
+        }
+        activeApplication->SetXrActive(active != 0);
+        if (active) {
+            emscripten_pause_main_loop();
+        } else {
+            emscripten_resume_main_loop();
+        }
+    }
+    EMSCRIPTEN_KEEPALIVE void SetXrEyeCount(int count) {
+        if (activeApplication) {
+            activeApplication->SetXrEyeCount(count);
+        }
+    }
+    EMSCRIPTEN_KEEPALIVE void SetXrEyeViewport(int eye, int x, int y, int width, int height) {
+        if (activeApplication) {
+            activeApplication->SetXrEyeViewport(eye, x, y, width, height);
+        }
+    }
+    EMSCRIPTEN_KEEPALIVE float* GetXrMatrixScratch() {
+        return activeApplication ? activeApplication->GetXrMatrixScratch() : nullptr;
+    }
+    EMSCRIPTEN_KEEPALIVE void CommitXrEyeMatrices(int eye) {
+        if (activeApplication) {
+            activeApplication->CommitXrEyeMatrices(eye);
+        }
+    }
+    EMSCRIPTEN_KEEPALIVE void RunXrFrame() {
+        if (activeApplication) {
+            activeApplication->RunOneFrame();
+        }
+    }
+    EMSCRIPTEN_KEEPALIVE float GetCameraPositionX() {
+        return activeApplication ? activeApplication->GetCamera().GetPosition().x : 0.0f;
+    }
+    EMSCRIPTEN_KEEPALIVE float GetCameraPositionY() {
+        return activeApplication ? activeApplication->GetCamera().GetPosition().y : 0.0f;
+    }
+    EMSCRIPTEN_KEEPALIVE float GetCameraPositionZ() {
+        return activeApplication ? activeApplication->GetCamera().GetPosition().z : 0.0f;
     }
 }
 #endif
@@ -308,7 +354,12 @@ void Application::RunOneFrame() {
     _fpsHandler.RunFrameTimer();
 
     if (_appState == AppState::LOADING) {
-        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+#ifdef __EMSCRIPTEN__
+        if (!_xr.active)
+#endif
+        {
+            glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        }
         glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
         glClear(GL_COLOR_BUFFER_BIT);
         
@@ -321,7 +372,12 @@ void Application::RunOneFrame() {
              _appState = AppState::RUNNING;
         }
 
-        glfwSwapBuffers(_mainWindow);
+#ifdef __EMSCRIPTEN__
+        if (!_xr.active)
+#endif
+        {
+            glfwSwapBuffers(_mainWindow);
+        }
         glfwPollEvents();
 #ifndef __EMSCRIPTEN__
         _fpsHandler.WaitForFrameTimer();
@@ -341,29 +397,32 @@ void Application::RunOneFrame() {
 
     _camera.UpdateTransition(_deltaTime);
 
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
     ProcessInput(_mainWindow);
     UpdatePlanetSystemLoading();
     UpdateLOD();
-    ConfigureMainShaders();
-    _skyBox->Render(*_mainSkyBoxShader);
-    RenderOrbitPaths();
-    RenderStarCorona();
-    ProcessSceneComponentsRendering();
-    RenderAsteroidField();
+
 #ifdef __EMSCRIPTEN__
-    RenderPlanetProxyMarkers();
+    if (_xr.active) {
+        RenderXrStereoFrame();
+        TextureLoadingQueue::GetInstance().ProcessQueue();
+#ifdef SOLARSYSTEM_USE_SDL_MIXER
+        UpdateBackgroundMusic();
 #endif
-    RenderStarEffects();
+        UpdateSearchNearestPlanet();
+        glfwPollEvents();
+        return;
+    }
+#endif
+
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    RenderFrameContent();
 
     if (_isRenderPlanetStarDistances || _isRenderSatelliteDistances)
         RenderPlanetSatelliteStarDistances();
     if (_isRenderHints)
         RenderHints();
 
-    // Process texture loading queue
     TextureLoadingQueue::GetInstance().ProcessQueue();
     RenderTextureLoadingProgress();
 
@@ -379,6 +438,23 @@ void Application::RunOneFrame() {
 
 #ifndef __EMSCRIPTEN__
     _fpsHandler.WaitForFrameTimer();
+#endif
+}
+
+void Application::RenderFrameContent() {
+    ConfigureMainShaders();
+    _skyBox->Render(*_mainSkyBoxShader);
+    RenderOrbitPaths();
+    RenderStarCorona();
+    ProcessSceneComponentsRendering();
+    RenderAsteroidField();
+#ifdef __EMSCRIPTEN__
+    if (!_xr.active) {
+        RenderPlanetProxyMarkers();
+        RenderStarEffects();
+    }
+#else
+    RenderStarEffects();
 #endif
 }
 
@@ -1203,6 +1279,64 @@ void Application::ApplyShadowQuality(int quality) {
     ApplyRenderResources(settings.shadowResolution, settings.enableHdr);
     LogQualityTier(settings, _hdrEnabled, gShadowQuality);
 }
+
+#ifdef __EMSCRIPTEN__
+void Application::SetXrActive(bool active) {
+    _xr.active = active;
+    _xr.currentEye = 0;
+    if (!active) {
+        _xr.eyeCount = 0;
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        glViewport(0, 0, _displayWidth, _displayHeight);
+        glDisable(GL_SCISSOR_TEST);
+    }
+    std::cout << "[WebXR] session " << (active ? "active" : "inactive") << std::endl;
+}
+
+void Application::SetXrEyeCount(int count) {
+    _xr.eyeCount = std::clamp(count, 0, 2);
+}
+
+void Application::SetXrEyeViewport(int eye, int x, int y, int width, int height) {
+    if (eye < 0 || eye > 1) {
+        return;
+    }
+    auto& e = _xr.eyes[eye];
+    e.viewportX = x;
+    e.viewportY = y;
+    e.viewportWidth = std::max(width, 1);
+    e.viewportHeight = std::max(height, 1);
+}
+
+float* Application::GetXrMatrixScratch() {
+    return _xr.matrixScratch;
+}
+
+void Application::CommitXrEyeMatrices(int eye) {
+    if (eye < 0 || eye > 1) {
+        return;
+    }
+    auto& e = _xr.eyes[eye];
+    std::memcpy(glm::value_ptr(e.view), _xr.matrixScratch, 16 * sizeof(float));
+    std::memcpy(glm::value_ptr(e.projection), _xr.matrixScratch + 16, 16 * sizeof(float));
+}
+
+void Application::RenderXrStereoFrame() {
+    // JS has already bound the XRWebGLLayer framebuffer and cleared it.
+    const int eyes = std::clamp(_xr.eyeCount, 0, 2);
+    for (int eye = 0; eye < eyes; ++eye) {
+        _xr.currentEye = eye;
+        const auto& e = _xr.eyes[eye];
+        glViewport(e.viewportX, e.viewportY, e.viewportWidth, e.viewportHeight);
+        glEnable(GL_SCISSOR_TEST);
+        glScissor(e.viewportX, e.viewportY, e.viewportWidth, e.viewportHeight);
+        glClear(GL_DEPTH_BUFFER_BIT);
+        glDisable(GL_SCISSOR_TEST);
+        RenderFrameContent();
+    }
+    _xr.currentEye = 0;
+}
+#endif
 
 Application::~Application() {
     if (activeApplication == this) {

--- a/src/Application.h
+++ b/src/Application.h
@@ -6,6 +6,7 @@
 #include "Solar_System/AsteroidField.h"
 #include "Solar_System/SolarSystem.h"
 #include "SystemModules.h"
+#include "XrState.h"
 #include <atomic>
 #include <functional>
 #include <unordered_set>
@@ -26,7 +27,15 @@ public:
     Application();
     ~Application();
     void Exec();
-    void RunOneFrame(); // For Emscripten main loop
+    void RunOneFrame(); // For Emscripten main loop / XR RAF
+#ifdef __EMSCRIPTEN__
+    void SetXrActive(bool active);
+    bool IsXrActive() const { return _xr.active; }
+    void SetXrEyeCount(int count);
+    void SetXrEyeViewport(int eye, int x, int y, int width, int height);
+    float* GetXrMatrixScratch();
+    void CommitXrEyeMatrices(int eye);
+#endif
     void ApplyQualityPreset(int preset);
     void ApplyShadowQuality(int quality);
     void ApplyOrbitScaleMode(int mode);
@@ -60,6 +69,10 @@ private:
     bool _isRenderSatelliteDistances = true;
     bool _isVertSyncEnabled = true;
     bool _orbitLinesEnabled = true;
+
+#ifdef __EMSCRIPTEN__
+    XrFrameState _xr;
+#endif
 
     enum class AppState { LOADING, RUNNING };
     AppState _appState = AppState::LOADING;
@@ -151,6 +164,10 @@ private:
     void RenderPlanetProxyMarkers() const; // Show orbital markers for unloaded planets (WASM)
     void RenderOrbitPaths() const;
     void RenderAsteroidField();
+    void RenderFrameContent(); // Sky → planets → effects (one eye / mono)
+#ifdef __EMSCRIPTEN__
+    void RenderXrStereoFrame();
+#endif
     void StartSearchNearestPlanet();
     void UpdateSearchNearestPlanet(); // For Emscripten frame-based search
     void StartPlayBackgroundMusic();

--- a/src/SceneRenderer.cpp
+++ b/src/SceneRenderer.cpp
@@ -42,6 +42,14 @@ void Application::ProcessSceneComponentsRendering() {
 }
 
 void Application::ShadowMapPass(const RenderableSceneComponent& component) {
+#ifdef __EMSCRIPTEN__
+    // XR presents into XRWebGLLayer's framebuffer (bound by JS). The normal
+    // shadow pass rebinds FBO 0 on exit, which would break stereo output — skip
+    // self-shadow maps in VR for now (lighting reads a cleared map as fully lit).
+    if (_xr.active) {
+        return;
+    }
+#endif
     glBindFramebuffer(GL_FRAMEBUFFER, _shadowMapFBO->GetFBO());
     glClear(GL_DEPTH_BUFFER_BIT);
     glViewport(0, 0, _shadowMapFBO->GetShadowMapWidth(), _shadowMapFBO->GetShadowMapHeight());
@@ -70,7 +78,15 @@ void Application::ShadowMapPass(const RenderableSceneComponent& component) {
 }
 
 void Application::RenderPass(const RenderableSceneComponent& component) {
-    glViewport(0, 0, _displayWidth, _displayHeight);
+#ifdef __EMSCRIPTEN__
+    if (_xr.active && _xr.currentEye >= 0 && _xr.currentEye < 2) {
+        const auto& eye = _xr.eyes[_xr.currentEye];
+        glViewport(eye.viewportX, eye.viewportY, eye.viewportWidth, eye.viewportHeight);
+    } else
+#endif
+    {
+        glViewport(0, 0, _displayWidth, _displayHeight);
+    }
     _mainPlanetShader->Use();
 
     ConfigureMainPlanetShader(component);
@@ -516,10 +532,24 @@ void Application::RenderTextureLoadingProgress() const {
 void Application::ConfigureMainShaders() {
     static const double zCoef = 2.0 / glm::log2(_camera.GetFar() + 1.0);
 
-    static const glm::mat4 skyBoxProjection = glm::perspective(glm::radians(45.0f), _camera.GetAspect(), _camera.GetNear(), _camera.GetFar());
+#ifdef __EMSCRIPTEN__
+    if (_xr.active && _xr.currentEye >= 0 && _xr.currentEye < _xr.eyeCount) {
+        const auto& eye = _xr.eyes[_xr.currentEye];
+        _cameraProjection = eye.projection;
+        _cameraView = eye.view;
+    } else
+#endif
+    {
+        _cameraProjection = _camera.GetProjectionMatrix();
+        _cameraView = _camera.GetViewMatrix();
+    }
 
-    _cameraProjection = _camera.GetProjectionMatrix();
-    _cameraView = _camera.GetViewMatrix();
+    // Skybox uses the active view's rotation; projection matches the eye frustum in XR.
+    const glm::mat4 skyBoxProjection =
+#ifdef __EMSCRIPTEN__
+        (_xr.active) ? _cameraProjection :
+#endif
+        glm::perspective(glm::radians(45.0f), _camera.GetAspect(), _camera.GetNear(), _camera.GetFar());
 
     _mainSkyBoxShader->Use();
     _mainSkyBoxShader->SetMat4("view", glm::mat4(glm::mat3(_cameraView)));

--- a/src/XrState.h
+++ b/src/XrState.h
@@ -1,0 +1,25 @@
+#ifndef SOLARSYSTEM_XRSTATE_H
+#define SOLARSYSTEM_XRSTATE_H
+
+#include <glm/glm.hpp>
+
+/** Shared WebXR stereo state (Emscripten / WebGL 2 only). */
+struct XrEyeState {
+    glm::mat4 view{1.0f};
+    glm::mat4 projection{1.0f};
+    int viewportX = 0;
+    int viewportY = 0;
+    int viewportWidth = 0;
+    int viewportHeight = 0;
+};
+
+struct XrFrameState {
+    bool active = false;
+    int eyeCount = 0;
+    int currentEye = 0;
+    XrEyeState eyes[2]{};
+    /** Scratch: [0..15]=view, [16..31]=proj for CommitXrEyeMatrices. */
+    float matrixScratch[32]{};
+};
+
+#endif // SOLARSYSTEM_XRSTATE_H

--- a/web/index.html
+++ b/web/index.html
@@ -231,6 +231,8 @@
           </label>
 
           <button id="settings-reset" class="settings-reset" type="button">Reset settings</button>
+          <button id="enter-vr" class="settings-vr" type="button" hidden>Enter VR</button>
+          <button id="exit-vr" class="settings-vr settings-vr-exit" type="button" hidden>Exit VR</button>
         </fieldset>
         <p id="settings-status" class="settings-status" aria-live="polite">Initializing controls…</p>
       </div>

--- a/web/src/SolarSystem.d.ts
+++ b/web/src/SolarSystem.d.ts
@@ -57,6 +57,20 @@ export type GetPlanetSceneDistance = (index: PlanetIndex) => number;
 export type SetOrbitLines = (enabled: number) => void;
 export type GetOrbitLines = () => number;
 
+export type SetXrSessionActive = (active: number) => void;
+export type SetXrEyeCount = (count: number) => void;
+export type SetXrEyeViewport = (
+  eye: number,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+) => void;
+export type GetXrMatrixScratch = () => number;
+export type CommitXrEyeMatrices = (eye: number) => void;
+export type RunXrFrame = () => void;
+export type GetCameraPositionComponent = () => number;
+
 export interface SolarSystemCwrap {
   (
     ident: 'SetCameraPose',
@@ -193,6 +207,51 @@ export interface SolarSystemCwrap {
     returnType: 'number',
     argTypes: [],
   ): GetOrbitLines;
+  (
+    ident: 'SetXrSessionActive',
+    returnType: null,
+    argTypes: ['number'],
+  ): SetXrSessionActive;
+  (
+    ident: 'SetXrEyeCount',
+    returnType: null,
+    argTypes: ['number'],
+  ): SetXrEyeCount;
+  (
+    ident: 'SetXrEyeViewport',
+    returnType: null,
+    argTypes: ['number', 'number', 'number', 'number', 'number'],
+  ): SetXrEyeViewport;
+  (
+    ident: 'GetXrMatrixScratch',
+    returnType: 'number',
+    argTypes: [],
+  ): GetXrMatrixScratch;
+  (
+    ident: 'CommitXrEyeMatrices',
+    returnType: null,
+    argTypes: ['number'],
+  ): CommitXrEyeMatrices;
+  (
+    ident: 'RunXrFrame',
+    returnType: null,
+    argTypes: [],
+  ): RunXrFrame;
+  (
+    ident: 'GetCameraPositionX',
+    returnType: 'number',
+    argTypes: [],
+  ): GetCameraPositionComponent;
+  (
+    ident: 'GetCameraPositionY',
+    returnType: 'number',
+    argTypes: [],
+  ): GetCameraPositionComponent;
+  (
+    ident: 'GetCameraPositionZ',
+    returnType: 'number',
+    argTypes: [],
+  ): GetCameraPositionComponent;
 }
 
 export interface SolarSystemModuleConfig {
@@ -201,11 +260,19 @@ export interface SolarSystemModuleConfig {
   print?: (text: string) => void;
   printErr?: (text: string) => void;
   onRuntimeInitialized?: () => void;
+  /** Passed through to Emscripten's WebGL context creation (GLFW). */
+  contextAttributes?: {
+    xrCompatible?: boolean;
+    majorVersion?: number;
+    minorVersion?: number;
+    antialias?: boolean;
+  };
 }
 
 export interface SolarSystemModule {
   canvas: HTMLCanvasElement;
   cwrap: SolarSystemCwrap;
+  HEAPF32: Float32Array;
   _main: (argc: number, argv: number) => number;
   _SetCameraPose: SetCameraPose;
   _SetQualityPreset: SetQualityPreset;
@@ -273,6 +340,15 @@ declare global {
     getPlanetSceneDistance?: GetPlanetSceneDistance;
     setOrbitLines?: SetOrbitLines;
     getOrbitLines?: GetOrbitLines;
+    setXrSessionActive?: SetXrSessionActive;
+    setXrEyeCount?: SetXrEyeCount;
+    setXrEyeViewport?: SetXrEyeViewport;
+    getXrMatrixScratch?: GetXrMatrixScratch;
+    commitXrEyeMatrices?: CommitXrEyeMatrices;
+    runXrFrame?: RunXrFrame;
+    getCameraPositionX?: GetCameraPositionComponent;
+    getCameraPositionY?: GetCameraPositionComponent;
+    getCameraPositionZ?: GetCameraPositionComponent;
     onPlanetFocused?: (index: number) => void;
     __solarSystemAssetBase?: string;
   }

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -7,6 +7,7 @@ import Module, {
 } from './SolarSystem.js'
 import { initTouchControls, isMobileLikeDevice } from './touchControls'
 import { PlanetExplorer } from './planetExplorer'
+import { initWebXr } from './webxr'
 
 // Emscripten 6 prefers resizable WebAssembly buffers when the browser exposes
 // toResizableBuffer(). Current Chrome DOM/WebGL APIs reject views backed by
@@ -47,6 +48,8 @@ const musicVolumeValue = document.getElementById('music-volume-value') as HTMLOu
 const musicMutedInput = document.getElementById('music-muted') as HTMLInputElement;
 const settingsReset = document.getElementById('settings-reset') as HTMLButtonElement;
 const settingsStatus = document.getElementById('settings-status') as HTMLElement;
+const enterVrButton = document.getElementById('enter-vr') as HTMLButtonElement;
+const exitVrButton = document.getElementById('exit-vr') as HTMLButtonElement;
 const explorerPanel = document.getElementById('explorer-panel') as HTMLElement;
 const deployedBaseUrl = new URL(import.meta.env.BASE_URL, window.location.href);
 const isMobileDevice = isMobileLikeDevice();
@@ -297,6 +300,12 @@ for (const eventName of ['pointerdown', 'pointerup', 'click', 'keydown', 'keyup'
 
 const moduleConfig: SolarSystemModuleConfig = {
     canvas: canvas,
+    // Request an XR-compatible context up front so makeXRCompatible() can succeed.
+    contextAttributes: {
+        xrCompatible: true,
+        majorVersion: 2,
+        minorVersion: 0,
+    },
     // Keep Emscripten runtime artifacts under the deployed Vite base path.
     locateFile: (path: string, prefix: string) => {
         if (path.endsWith('.wasm') || path.endsWith('.data')) {
@@ -342,6 +351,16 @@ Module(moduleConfig).then((instance) => {
     window.setOrbitLines = instance.cwrap('SetOrbitLines', null, ['number']);
     window.getOrbitLines = instance.cwrap('GetOrbitLines', 'number', []);
 
+    window.setXrSessionActive = instance.cwrap('SetXrSessionActive', null, ['number']);
+    window.setXrEyeCount = instance.cwrap('SetXrEyeCount', null, ['number']);
+    window.setXrEyeViewport = instance.cwrap('SetXrEyeViewport', null, ['number', 'number', 'number', 'number', 'number']);
+    window.getXrMatrixScratch = instance.cwrap('GetXrMatrixScratch', 'number', []);
+    window.commitXrEyeMatrices = instance.cwrap('CommitXrEyeMatrices', null, ['number']);
+    window.runXrFrame = instance.cwrap('RunXrFrame', null, []);
+    window.getCameraPositionX = instance.cwrap('GetCameraPositionX', 'number', []);
+    window.getCameraPositionY = instance.cwrap('GetCameraPositionY', 'number', []);
+    window.getCameraPositionZ = instance.cwrap('GetCameraPositionZ', 'number', []);
+
     const explorer = new PlanetExplorer(explorerPanel);
     void explorer.init({
         focusPlanet: window.focusPlanet,
@@ -375,6 +394,56 @@ Module(moduleConfig).then((instance) => {
                 window.addTouchZoom?.(delta);
             },
         },
+    });
+
+    void initWebXr({
+        canvas,
+        enterVrButton,
+        exitVrButton,
+        overlayRoots: [settingsPanel, explorerPanel],
+        bindings: {
+            setTouchMovement: (forward, right, vertical) => {
+                window.setTouchMovement?.(forward, right, vertical);
+            },
+            addTouchLook: (deltaX, deltaY) => {
+                window.addTouchLook?.(deltaX, deltaY);
+            },
+            setQualityPreset: (preset) => {
+                window.setQualityPreset?.(preset);
+            },
+            getQualityPreset: () => window.getQualityPreset?.() ?? 2,
+            getCameraPosition: () => ({
+                x: window.getCameraPositionX?.() ?? 0,
+                y: window.getCameraPositionY?.() ?? 0,
+                z: window.getCameraPositionZ?.() ?? 0,
+            }),
+            setXrSessionActive: (active) => {
+                window.setXrSessionActive?.(active ? 1 : 0);
+            },
+            setXrEyeCount: (count) => {
+                window.setXrEyeCount?.(count);
+            },
+            setXrEyeViewport: (eye, x, y, w, h) => {
+                window.setXrEyeViewport?.(eye, x, y, w, h);
+            },
+            commitXrEyeMatrices: (eye) => {
+                window.commitXrEyeMatrices?.(eye);
+            },
+            getXrMatrixScratchPtr: () => window.getXrMatrixScratch?.() ?? 0,
+            runXrFrame: () => {
+                window.runXrFrame?.();
+            },
+            getHeapF32: () => instance.HEAPF32,
+        },
+    }).then((controller) => {
+        if (controller) {
+            console.log('[WebXR] Enter VR control ready');
+        } else {
+            console.log('[WebXR] immersive-vr unavailable — staying 2D');
+        }
+    }).catch((error: unknown) => {
+        console.warn('[WebXR] init failed:', error);
+        enterVrButton.hidden = true;
     });
 
     const saved = readPersistedSettings();

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -252,6 +252,33 @@ input {
   background: rgba(255, 255, 255, 0.13);
 }
 
+.settings-vr {
+  width: 100%;
+  min-height: 44px;
+  margin-top: 8px;
+  color: #e8f7ff;
+  background: rgba(40, 120, 180, 0.35);
+  border: 1px solid rgba(120, 200, 255, 0.45);
+  border-radius: 8px;
+  cursor: pointer;
+  touch-action: manipulation;
+  font-weight: 600;
+}
+
+.settings-vr:hover:not(:disabled) {
+  background: rgba(50, 140, 200, 0.5);
+}
+
+.settings-vr:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.settings-vr-exit {
+  background: rgba(140, 60, 60, 0.4);
+  border-color: rgba(255, 140, 140, 0.45);
+}
+
 .settings-status {
   min-height: 18px;
   margin: 9px 0 0;

--- a/web/src/webxr-dom.d.ts
+++ b/web/src/webxr-dom.d.ts
@@ -1,0 +1,100 @@
+/**
+ * Minimal WebXR DOM typings for browsers that expose navigator.xr.
+ * Full @types/webxr is optional; these cover the immersive-vr surface we use.
+ */
+
+interface XRSession extends EventTarget {
+  inputSources: readonly XRInputSource[];
+  renderState: XRRenderState;
+  updateRenderState(state: XRRenderStateInit): Promise<void>;
+  requestReferenceSpace(type: XRReferenceSpaceType): Promise<XRReferenceSpace>;
+  requestAnimationFrame(callback: XRFrameRequestCallback): number;
+  cancelAnimationFrame(handle: number): void;
+  end(): Promise<void>;
+  addEventListener(type: 'end', listener: (event: Event) => void): void;
+}
+
+interface XRRenderState {
+  baseLayer: XRWebGLLayer | null;
+  depthNear: number;
+  depthFar: number;
+}
+
+interface XRRenderStateInit {
+  baseLayer?: XRWebGLLayer | null;
+  depthNear?: number;
+  depthFar?: number;
+}
+
+type XRReferenceSpaceType = 'local' | 'local-floor' | 'bounded-floor' | 'unbounded' | 'viewer';
+
+interface XRReferenceSpace extends EventTarget {}
+
+interface XRFrame {
+  session: XRSession;
+  getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | null;
+}
+
+interface XRViewerPose {
+  views: readonly XRView[];
+}
+
+interface XRView {
+  eye: 'left' | 'right' | 'none';
+  projectionMatrix: Float32Array;
+  transform: XRRigidTransform;
+}
+
+interface XRRigidTransform {
+  matrix: Float32Array;
+  inverse: XRRigidTransform;
+}
+
+interface XRWebGLLayerInit {
+  antialias?: boolean;
+  depth?: boolean;
+  stencil?: boolean;
+  alpha?: boolean;
+  ignoreDepthValues?: boolean;
+  framebufferScaleFactor?: number;
+}
+
+declare class XRWebGLLayer {
+  constructor(session: XRSession, context: WebGLRenderingContext | WebGL2RenderingContext, layerInit?: XRWebGLLayerInit);
+  readonly framebuffer: WebGLFramebuffer | null;
+  getViewport(view: XRView): XRViewport | null;
+}
+
+interface XRViewport {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+type XRHandedness = 'none' | 'left' | 'right';
+
+interface XRInputSource {
+  handedness: XRHandedness;
+  gamepad: Gamepad | null;
+}
+
+type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame) => void;
+
+interface XRSessionInit {
+  requiredFeatures?: string[];
+  optionalFeatures?: string[];
+}
+
+interface XRSystem {
+  isSessionSupported(mode: 'inline' | 'immersive-vr' | 'immersive-ar'): Promise<boolean>;
+  requestSession(mode: 'inline' | 'immersive-vr' | 'immersive-ar', options?: XRSessionInit): Promise<XRSession>;
+}
+
+interface Navigator {
+  readonly xr?: XRSystem;
+}
+
+interface WebGL2RenderingContext {
+  makeXRCompatible(): Promise<void>;
+}

--- a/web/src/webxr.ts
+++ b/web/src/webxr.ts
@@ -80,12 +80,19 @@ export async function initWebXr(options: {
   const xr = navigator.xr;
   if (!xr || typeof xr.isSessionSupported !== 'function') {
     enterVrButton.hidden = true;
+    console.log('[WebXR] navigator.xr unavailable — staying 2D');
     return null;
   }
 
+  console.log('[WebXR] Checking immersive-vr support…');
   let supported = false;
   try {
-    supported = await xr.isSessionSupported('immersive-vr');
+    supported = await Promise.race([
+      xr.isSessionSupported('immersive-vr'),
+      new Promise<boolean>((resolve) => {
+        window.setTimeout(() => resolve(false), 2000);
+      }),
+    ]);
   } catch (error) {
     console.warn('[WebXR] isSessionSupported failed:', error);
     enterVrButton.hidden = true;
@@ -94,6 +101,7 @@ export async function initWebXr(options: {
 
   if (!supported) {
     enterVrButton.hidden = true;
+    console.log('[WebXR] immersive-vr not supported — staying 2D');
     return null;
   }
 

--- a/web/src/webxr.ts
+++ b/web/src/webxr.ts
@@ -1,0 +1,342 @@
+/**
+ * Opt-in WebXR immersive-vr session for the WASM renderer.
+ * Controllers map to SetTouchMovement / AddTouchLook; eye matrices are
+ * pushed into C++ each XR frame for stereo rendering.
+ */
+
+export type XrBindings = {
+  setTouchMovement: (forward: number, right: number, vertical: number) => void;
+  addTouchLook: (deltaX: number, deltaY: number) => void;
+  setQualityPreset: (preset: 0 | 1 | 2) => void;
+  getQualityPreset: () => number;
+  getCameraPosition: () => { x: number; y: number; z: number };
+  setXrSessionActive: (active: boolean) => void;
+  setXrEyeCount: (count: number) => void;
+  setXrEyeViewport: (eye: number, x: number, y: number, w: number, h: number) => void;
+  commitXrEyeMatrices: (eye: number) => void;
+  getXrMatrixScratchPtr: () => number;
+  runXrFrame: () => void;
+  getHeapF32: () => Float32Array;
+};
+
+export type WebXrController = {
+  /** Tear down listeners / end session if active. */
+  dispose: () => void;
+  /** True when an immersive-vr session is running. */
+  isPresenting: () => boolean;
+};
+
+const XR_DEPTH_NEAR = 0.001;
+const XR_DEPTH_FAR = 20000;
+const SNAP_TURN_DEG = 30;
+const SNAP_TURN_COOLDOWN_MS = 350;
+
+function multiplyMat4(a: Float32Array, b: Float32Array, out: Float32Array): void {
+  const r = new Float32Array(16);
+  for (let col = 0; col < 4; ++col) {
+    for (let row = 0; row < 4; ++row) {
+      r[col * 4 + row] =
+        a[0 * 4 + row] * b[col * 4 + 0] +
+        a[1 * 4 + row] * b[col * 4 + 1] +
+        a[2 * 4 + row] * b[col * 4 + 2] +
+        a[3 * 4 + row] * b[col * 4 + 3];
+    }
+  }
+  out.set(r);
+}
+
+function translationMat4(x: number, y: number, z: number, out: Float32Array): void {
+  out.fill(0);
+  out[0] = 1;
+  out[5] = 1;
+  out[10] = 1;
+  out[15] = 1;
+  out[12] = x;
+  out[13] = y;
+  out[14] = z;
+}
+
+function clampAxis(v: number, deadzone = 0.15): number {
+  if (Math.abs(v) < deadzone) {
+    return 0;
+  }
+  const sign = v < 0 ? -1 : 1;
+  return sign * Math.min(1, (Math.abs(v) - deadzone) / (1 - deadzone));
+}
+
+/**
+ * Show #enter-vr when immersive-vr is available; hide otherwise.
+ * Returns a controller, or null when WebXR is unavailable.
+ */
+export async function initWebXr(options: {
+  canvas: HTMLCanvasElement;
+  enterVrButton: HTMLButtonElement;
+  exitVrButton?: HTMLButtonElement | null;
+  overlayRoots?: HTMLElement[];
+  bindings: XrBindings;
+}): Promise<WebXrController | null> {
+  const { canvas, enterVrButton, exitVrButton, overlayRoots = [], bindings } = options;
+
+  const xr = navigator.xr;
+  if (!xr || typeof xr.isSessionSupported !== 'function') {
+    enterVrButton.hidden = true;
+    return null;
+  }
+
+  let supported = false;
+  try {
+    supported = await xr.isSessionSupported('immersive-vr');
+  } catch (error) {
+    console.warn('[WebXR] isSessionSupported failed:', error);
+    enterVrButton.hidden = true;
+    return null;
+  }
+
+  if (!supported) {
+    enterVrButton.hidden = true;
+    return null;
+  }
+
+  enterVrButton.hidden = false;
+  enterVrButton.disabled = false;
+
+  let session: XRSession | null = null;
+  let referenceSpace: XRReferenceSpace | null = null;
+  let gl: WebGL2RenderingContext | null = null;
+  let qualityBeforeVr: number | null = null;
+  let lastSnapTurnMs = 0;
+  let rafHandle = 0;
+
+  const scratchView = new Float32Array(16);
+  const scratchPlayerInv = new Float32Array(16);
+  const scratchCombined = new Float32Array(16);
+
+  const setOverlaysVisible = (visible: boolean) => {
+    for (const el of overlayRoots) {
+      el.style.visibility = visible ? '' : 'hidden';
+      el.style.pointerEvents = visible ? '' : 'none';
+    }
+    enterVrButton.hidden = !visible ? true : false;
+    if (exitVrButton) {
+      exitVrButton.hidden = visible;
+    }
+  };
+
+  const endSession = async () => {
+    if (session) {
+      try {
+        await session.end();
+      } catch {
+        /* already ended */
+      }
+    }
+  };
+
+  const onSessionEnded = () => {
+    if (rafHandle) {
+      // XR RAF cancels with session end; clear our handle.
+      rafHandle = 0;
+    }
+    session = null;
+    referenceSpace = null;
+    bindings.setTouchMovement(0, 0, 0);
+    bindings.setXrSessionActive(false);
+    if (qualityBeforeVr !== null) {
+      bindings.setQualityPreset(qualityBeforeVr as 0 | 1 | 2);
+      qualityBeforeVr = null;
+    }
+    setOverlaysVisible(true);
+    enterVrButton.hidden = false;
+    enterVrButton.textContent = 'Enter VR';
+    enterVrButton.disabled = false;
+    console.log('[WebXR] Session ended — resumed 2D main loop');
+  };
+
+  const pollControllers = (frame: XRFrame) => {
+    if (!session) {
+      return;
+    }
+    let forward = 0;
+    let right = 0;
+    let vertical = 0;
+    let lookX = 0;
+
+    for (const source of session.inputSources) {
+      const pad = source.gamepad;
+      if (!pad) {
+        continue;
+      }
+      // xr-standard: axes 2/3 = thumbstick; fall back to 0/1.
+      const ax = clampAxis(pad.axes[2] ?? pad.axes[0] ?? 0);
+      const ay = clampAxis(pad.axes[3] ?? pad.axes[1] ?? 0);
+      const handedness = source.handedness;
+
+      if (handedness === 'left' || handedness === 'none') {
+        // Match touch joystick: forward = -Y, right = +X
+        forward += -ay;
+        right += ax;
+        if (pad.buttons[1]?.pressed) {
+          // Grip → boost vertical climb when also pressing stick? Use grip as up.
+          vertical += 0.85;
+        }
+      } else if (handedness === 'right') {
+        vertical += -ay;
+        // Snap-turn on strong X deflection
+        const now = performance.now();
+        if (Math.abs(ax) > 0.7 && now - lastSnapTurnMs > SNAP_TURN_COOLDOWN_MS) {
+          lookX = ax > 0 ? SNAP_TURN_DEG : -SNAP_TURN_DEG;
+          lastSnapTurnMs = now;
+        }
+      }
+
+      void frame; // pose reserved for future hand/controller models
+    }
+
+    const mag = Math.hypot(forward, right, vertical);
+    if (mag > 1) {
+      forward /= mag;
+      right /= mag;
+      vertical /= mag;
+    }
+    bindings.setTouchMovement(forward, right, vertical);
+    if (lookX !== 0) {
+      bindings.addTouchLook(lookX, 0);
+    }
+  };
+
+  const onXrFrame = (time: number, frame: XRFrame) => {
+    if (!session || !referenceSpace || !gl) {
+      return;
+    }
+    rafHandle = session.requestAnimationFrame(onXrFrame);
+
+    const pose = frame.getViewerPose(referenceSpace);
+    const layer = session.renderState.baseLayer;
+    if (!pose || !layer) {
+      return;
+    }
+
+    pollControllers(frame);
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, layer.framebuffer);
+    gl.clearColor(0, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    const cam = bindings.getCameraPosition();
+    translationMat4(-cam.x, -cam.y, -cam.z, scratchPlayerInv);
+
+    const views = pose.views;
+    bindings.setXrEyeCount(views.length);
+
+    const scratchBase = bindings.getXrMatrixScratchPtr() >> 2;
+
+    for (let eye = 0; eye < views.length && eye < 2; ++eye) {
+      const view = views[eye];
+      const viewport = layer.getViewport(view);
+      if (!viewport) {
+        continue;
+      }
+      bindings.setXrEyeViewport(eye, viewport.x, viewport.y, viewport.width, viewport.height);
+
+      // view.transform.inverse.matrix: stage → eye (column-major).
+      // Combined with T(-camera) so touch/controller flight still moves the stage.
+      const xrView = view.transform.inverse.matrix as Float32Array;
+      scratchView.set(xrView);
+      multiplyMat4(scratchView, scratchPlayerInv, scratchCombined);
+
+      const proj = view.projectionMatrix as Float32Array;
+      const heap = bindings.getHeapF32();
+      heap.set(scratchCombined, scratchBase);
+      heap.set(proj, scratchBase + 16);
+      bindings.commitXrEyeMatrices(eye);
+    }
+
+    bindings.runXrFrame();
+    void time;
+  };
+
+  const startSession = async () => {
+    if (session) {
+      return;
+    }
+    enterVrButton.disabled = true;
+    enterVrButton.textContent = 'Entering VR…';
+
+    try {
+      gl = canvas.getContext('webgl2');
+      if (!gl) {
+        throw new Error('WebGL2 context not available on canvas');
+      }
+      if (typeof gl.makeXRCompatible === 'function') {
+        await gl.makeXRCompatible();
+      }
+
+      session = await xr.requestSession('immersive-vr', {
+        requiredFeatures: ['local-floor'],
+        optionalFeatures: ['local', 'bounded-floor'],
+      });
+
+      const layer = new XRWebGLLayer(session, gl, {
+        antialias: false,
+        framebufferScaleFactor: 1.0,
+      });
+      await session.updateRenderState({
+        baseLayer: layer,
+        depthNear: XR_DEPTH_NEAR,
+        depthFar: XR_DEPTH_FAR,
+      });
+
+      referenceSpace =
+        (await session.requestReferenceSpace('local-floor').catch(() => null)) ||
+        (await session.requestReferenceSpace('local'));
+
+      qualityBeforeVr = bindings.getQualityPreset();
+      // Prefer medium in VR (low if already low); MSAA is fixed at context creation.
+      const vrPreset = (qualityBeforeVr <= 0 ? 0 : 1) as 0 | 1 | 2;
+      bindings.setQualityPreset(vrPreset);
+
+      session.addEventListener('end', onSessionEnded);
+      bindings.setXrSessionActive(true);
+      setOverlaysVisible(false);
+      if (exitVrButton) {
+        exitVrButton.hidden = false;
+      }
+      enterVrButton.textContent = 'Enter VR';
+      console.log('[WebXR] immersive-vr session started (quality preset', vrPreset, ')');
+
+      rafHandle = session.requestAnimationFrame(onXrFrame);
+    } catch (error) {
+      console.error('[WebXR] Failed to enter VR:', error);
+      enterVrButton.disabled = false;
+      enterVrButton.textContent = 'Enter VR';
+      session = null;
+      bindings.setXrSessionActive(false);
+    }
+  };
+
+  enterVrButton.addEventListener('click', (event) => {
+    event.stopPropagation();
+    void startSession();
+  });
+  for (const eventName of ['pointerdown', 'pointerup', 'keydown', 'keyup'] as const) {
+    enterVrButton.addEventListener(eventName, (event) => event.stopPropagation());
+  }
+
+  if (exitVrButton) {
+    exitVrButton.hidden = true;
+    exitVrButton.addEventListener('click', (event) => {
+      event.stopPropagation();
+      void endSession();
+    });
+    for (const eventName of ['pointerdown', 'pointerup', 'keydown', 'keyup'] as const) {
+      exitVrButton.addEventListener(eventName, (event) => event.stopPropagation());
+    }
+  }
+
+  return {
+    dispose: () => {
+      void endSession();
+    },
+    isPresenting: () => session !== null,
+  };
+}

--- a/web/threejs/README.md
+++ b/web/threejs/README.md
@@ -9,6 +9,7 @@ from, and does not replace, the C++/Emscripten WebGL 2 renderer.
 - Phase 1: complete — shared orbital JSON, DDS→KTX2 pipeline, Mercury through Mars,
   focus presets, OrbitControls, and damped WASD flight.
 - Next: low→high texture streaming, labels/proxies for outer planets, and simplified effects.
+- WebXR spike: on the **WebGLRenderer** fallback, Three's `VRButton` is attached (`renderer.xr.enabled`). The primary WASM app owns the full immersive-vr path — see `docs/plans/WEBXR_PLAN.md`.
 
 ## Run
 

--- a/web/threejs/package-lock.json
+++ b/web/threejs/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "threejs",
+  "name": "solar-system-threejs",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "threejs",
+      "name": "solar-system-threejs",
       "version": "0.0.0",
       "dependencies": {
         "@types/three": "^0.184.1",
@@ -178,9 +178,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -198,9 +195,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -218,9 +212,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -238,9 +229,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -258,9 +246,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -278,9 +263,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -602,9 +584,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -626,9 +605,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -650,9 +626,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -674,9 +647,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/web/threejs/src/main.ts
+++ b/web/threejs/src/main.ts
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import { WebGPURenderer } from 'three/webgpu';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
+import { VRButton } from 'three/addons/webxr/VRButton.js';
 import orbitalParametersJson from './data/orbital-parameters.json';
 
 interface OrbitalBody {
@@ -100,6 +101,15 @@ async function init(): Promise<void> {
 
   infoElement.textContent = `Phase 1 · ${rendererResult.backend} · 4 inner planets`;
   textureStatusElement.textContent = `KTX2 base: ${textureBase}`;
+
+  // WebXR spike on the classic WebGLRenderer path (see docs/plans/WEBXR_PLAN.md).
+  if (renderer instanceof THREE.WebGLRenderer) {
+    renderer.xr.enabled = true;
+    const vrButton = VRButton.createButton(renderer);
+    vrButton.style.position = 'fixed';
+    document.body.appendChild(vrButton);
+  }
+
   renderer.setAnimationLoop(animate);
   console.info('[threejs-companion] Phase 1 ready', {
     backend: rendererResult.backend,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds an opt-in **Enter VR** path for WebXR `immersive-vr`: stereoscopic eye rendering driven by XR view/projection matrices, controller flight via existing touch bindings, and a no-op (hidden button) on browsers without XR.

## Changes
- **`web/src/webxr.ts`**: session lifecycle, `XRWebGLLayer`, per-eye matrix upload, controller → `SetTouchMovement` / `AddTouchLook`; support probe times out cleanly when XR is partial/unavailable
- **C++**: `SetXrSessionActive`, eye viewport/matrix scratch APIs, `RunXrFrame` stereo loop (skips FBO 0 swap, shadow maps, and HDR composite while presenting)
- **UI**: Enter/Exit VR buttons in settings (hidden unless `isSessionSupported('immersive-vr')`)
- **Quality**: VR entry prefers medium (keeps low); MSAA trade-off documented in `docs/plans/WEBXR_PLAN.md` + Testing Guide
- **Three.js spike**: `VRButton` on WebGLRenderer fallback in `web/threejs/`

## Acceptance
- [x] WebXR-capable browsers can request immersive-vr and receive stereo eye passes with head-tracked matrices + controller flight bindings
- [x] Non-XR browsers: button stays hidden; 2-D path unchanged (`./build-web.sh` + preview smoke)
- [x] Context requested with `xrCompatible: true`

## Notes
Full headset verification needs Chrome + WebXR Emulator or a Quest browser on HTTPS/`localhost`. This VM exercised the unavailable path (button remains `hidden`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd5693e5-9a00-4040-9634-ab8841daacf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd5693e5-9a00-4040-9634-ab8841daacf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

