### PR TITLE
Shareable deep-links and expanded planet info card

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -195,6 +195,12 @@ extern "C" {
     EMSCRIPTEN_KEEPALIVE float GetCameraPositionZ() {
         return activeApplication ? activeApplication->GetCamera().GetPosition().z : 0.0f;
     }
+    EMSCRIPTEN_KEEPALIVE float GetCameraYaw() {
+        return activeApplication ? activeApplication->GetCamera().GetYaw() : -90.0f;
+    }
+    EMSCRIPTEN_KEEPALIVE float GetCameraPitch() {
+        return activeApplication ? activeApplication->GetCamera().GetPitch() : 0.0f;
+    }
 }
 #endif
 

--- a/src/Auxiliary_Modules/Camera.h
+++ b/src/Auxiliary_Modules/Camera.h
@@ -30,6 +30,8 @@ public:
     glm::mat4 GetViewMatrix() const;
     glm::mat4 GetProjectionMatrix() const;
     glm::vec3 GetPosition() const;
+    float GetYaw() const { return _yaw; }
+    float GetPitch() const { return _pitch; }
     glm::vec3 GetRightVector() const;
     glm::vec3 GetFrontVector() const;
     glm::vec3 GetUpVector() const;

--- a/web/index.html
+++ b/web/index.html
@@ -140,7 +140,10 @@
         <div id="explorer-body-list" class="explorer-body-list" role="listbox" aria-label="Celestial bodies"></div>
 
         <article id="planet-info-card" class="planet-info-card" hidden>
-          <h2 id="planet-info-title" class="planet-info-title">Earth</h2>
+          <div id="planet-info-header" class="planet-info-header">
+            <h2 id="planet-info-title" class="planet-info-title">Earth</h2>
+            <button id="planet-info-dismiss" class="planet-info-dismiss" type="button" aria-label="Dismiss info card">×</button>
+          </div>
           <p id="planet-info-summary" class="planet-info-summary"></p>
           <dl id="planet-info-facts" class="planet-info-facts"></dl>
         </article>
@@ -231,6 +234,7 @@
           </label>
 
           <button id="settings-reset" class="settings-reset" type="button">Reset settings</button>
+          <button id="copy-view-link" class="settings-share" type="button">Copy link to this view</button>
           <button id="enter-vr" class="settings-vr" type="button" hidden>Enter VR</button>
           <button id="exit-vr" class="settings-vr settings-vr-exit" type="button" hidden>Exit VR</button>
         </fieldset>

--- a/web/public/planet_facts.json
+++ b/web/public/planet_facts.json
@@ -1,136 +1,170 @@
 {
-  "version": 1,
+  "version": 2,
   "sceneNote": "Distances in the 3D scene are artistic. Toggle scale mode to compare compressed orbits vs AU-proportional spacing.",
   "bodies": [
     {
       "index": 0,
       "id": "sun",
       "name": "Sun",
+      "nameRu": "Солнце",
       "type": "star",
       "diameterKm": 1392700,
       "massEarths": 333000,
+      "siderealRotationDays": 25.38,
       "orbitalPeriodDays": null,
       "distanceAu": 0,
       "moons": 0,
-      "summary": "G-type main-sequence star; contains 99.86% of the Solar System's mass."
+      "summary": "G-type main-sequence star; contains 99.86% of the Solar System's mass.",
+      "summaryRu": "Звезда спектрального класса G; содержит 99,86% массы Солнечной системы."
     },
     {
       "index": 1,
       "id": "mercury",
       "name": "Mercury",
+      "nameRu": "Меркурий",
       "type": "terrestrial",
       "diameterKm": 4879,
       "massEarths": 0.055,
+      "siderealRotationDays": 58.646,
       "orbitalPeriodDays": 88,
       "distanceAu": 0.387,
       "moons": 0,
-      "summary": "Smallest planet; extreme temperature swings between sunlit and shadowed hemispheres."
+      "summary": "Smallest planet; extreme temperature swings between sunlit and shadowed hemispheres.",
+      "summaryRu": "Самая маленькая планета; резкие перепады температуры между освещённой и теневой сторонами."
     },
     {
       "index": 2,
       "id": "venus",
       "name": "Venus",
+      "nameRu": "Венера",
       "type": "terrestrial",
       "diameterKm": 12104,
       "massEarths": 0.815,
+      "siderealRotationDays": -243.025,
       "orbitalPeriodDays": 225,
       "distanceAu": 0.723,
       "moons": 0,
-      "summary": "Dense CO₂ atmosphere drives a runaway greenhouse; surface hotter than Mercury."
+      "summary": "Dense CO₂ atmosphere drives a runaway greenhouse; surface hotter than Mercury.",
+      "summaryRu": "Плотная атмосфера CO₂ вызывает парниковый эффект; поверхность горячее, чем у Меркурия."
     },
     {
       "index": 3,
       "id": "earth",
       "name": "Earth",
+      "nameRu": "Земля",
       "type": "terrestrial",
       "diameterKm": 12742,
       "massEarths": 1,
+      "siderealRotationDays": 0.997,
       "orbitalPeriodDays": 365.25,
       "distanceAu": 1,
       "moons": 1,
-      "summary": "Only known world with stable liquid water on the surface and abundant life."
+      "summary": "Only known world with stable liquid water on the surface and abundant life.",
+      "summaryRu": "Единственный известный мир с устойчивой жидкой водой на поверхности и обилием жизни."
     },
     {
       "index": 4,
       "id": "mars",
       "name": "Mars",
+      "nameRu": "Марс",
       "type": "terrestrial",
       "diameterKm": 6779,
       "massEarths": 0.107,
+      "siderealRotationDays": 1.026,
       "orbitalPeriodDays": 687,
       "distanceAu": 1.524,
       "moons": 2,
-      "summary": "Iron-rich desert world with the largest volcano and canyon in the Solar System."
+      "summary": "Iron-rich desert world with the largest volcano and canyon in the Solar System.",
+      "summaryRu": "Пустынный мир, богатый железом, с крупнейшим вулканом и каньоном Солнечной системы."
     },
     {
       "index": 5,
       "id": "jupiter",
       "name": "Jupiter",
+      "nameRu": "Юпитер",
       "type": "gas_giant",
       "diameterKm": 139820,
       "massEarths": 318,
+      "siderealRotationDays": 0.414,
       "orbitalPeriodDays": 4333,
       "distanceAu": 5.203,
       "moons": 95,
-      "summary": "Most massive planet; Great Red Spot is a centuries-old anticyclonic storm."
+      "summary": "Most massive planet; Great Red Spot is a centuries-old anticyclonic storm.",
+      "summaryRu": "Самая массивная планета; Большое красное пятно — многовековой антициклонный шторм."
     },
     {
       "index": 6,
       "id": "saturn",
       "name": "Saturn",
+      "nameRu": "Сатурн",
       "type": "gas_giant",
       "diameterKm": 116460,
       "massEarths": 95,
+      "siderealRotationDays": 0.444,
       "orbitalPeriodDays": 10759,
       "distanceAu": 9.537,
       "moons": 146,
-      "summary": "Spectacular ring system of ice and rock; average density less than water."
+      "summary": "Spectacular ring system of ice and rock; average density less than water.",
+      "summaryRu": "Великолепная кольцевая система из льда и камня; средняя плотность меньше воды."
     },
     {
       "index": 7,
       "id": "uranus",
       "name": "Uranus",
+      "nameRu": "Уран",
       "type": "ice_giant",
       "diameterKm": 50724,
       "massEarths": 14.5,
+      "siderealRotationDays": -0.718,
       "orbitalPeriodDays": 30687,
       "distanceAu": 19.191,
       "moons": 28,
-      "summary": "Rotates on its side; faint rings and a methane haze give a blue-green hue."
+      "summary": "Rotates on its side; faint rings and a methane haze give a blue-green hue.",
+      "summaryRu": "Вращается «на боку»; слабые кольца и метановая дымка придают сине-зелёный оттенок."
     },
     {
       "index": 8,
       "id": "neptune",
       "name": "Neptune",
+      "nameRu": "Нептун",
       "type": "ice_giant",
       "diameterKm": 49244,
       "massEarths": 17.1,
+      "siderealRotationDays": 0.671,
       "orbitalPeriodDays": 60190,
       "distanceAu": 30.069,
       "moons": 16,
-      "summary": "Windiest planet; supersonic jet streams despite receiving little solar heat."
+      "summary": "Windiest planet; supersonic jet streams despite receiving little solar heat.",
+      "summaryRu": "Самая ветреная планета; сверхзвуковые струи ветра при слабом солнечном нагреве."
     },
     {
       "index": 9,
       "id": "pluto",
       "name": "Pluto",
+      "nameRu": "Плутон",
       "type": "dwarf_planet",
       "diameterKm": 2377,
       "massEarths": 0.0022,
+      "siderealRotationDays": 6.387,
       "orbitalPeriodDays": 90560,
       "distanceAu": 39.482,
       "moons": 5,
-      "summary": "Icy dwarf planet in the Kuiper Belt with a heart-shaped nitrogen glacier."
+      "summary": "Icy dwarf planet in the Kuiper Belt with a heart-shaped nitrogen glacier.",
+      "summaryRu": "Ледяная карликовая планета пояса Койпера с ледником азота в форме сердца."
     }
   ],
   "scaleModes": {
     "compressed": {
       "label": "Compressed orbits",
-      "description": "Artistic spacing for navigation — all worlds stay within a few thousand scene units."
+      "labelRu": "Сжатые орбиты",
+      "description": "Artistic spacing for navigation — all worlds stay within a few thousand scene units.",
+      "descriptionRu": "Художественные расстояния для навигации — все миры в пределах нескольких тысяч единиц сцены."
     },
     "realistic": {
       "label": "Realistic distances",
-      "description": "Orbit radii scaled to NASA semi-major axes (1 AU ≈ Earth's compressed distance). Vast empty space between worlds."
+      "labelRu": "Реалистичные расстояния",
+      "description": "Orbit radii scaled to NASA semi-major axes (1 AU ≈ Earth's compressed distance). Vast empty space between worlds.",
+      "descriptionRu": "Радиусы орбит по полуосям NASA (1 а.е. ≈ сжатое расстояние Земли). Огромные пустоты между мирами."
     }
   }
 }

--- a/web/src/SolarSystem.d.ts
+++ b/web/src/SolarSystem.d.ts
@@ -70,6 +70,8 @@ export type GetXrMatrixScratch = () => number;
 export type CommitXrEyeMatrices = (eye: number) => void;
 export type RunXrFrame = () => void;
 export type GetCameraPositionComponent = () => number;
+export type GetCameraYaw = () => number;
+export type GetCameraPitch = () => number;
 
 export interface SolarSystemCwrap {
   (
@@ -252,6 +254,16 @@ export interface SolarSystemCwrap {
     returnType: 'number',
     argTypes: [],
   ): GetCameraPositionComponent;
+  (
+    ident: 'GetCameraYaw',
+    returnType: 'number',
+    argTypes: [],
+  ): GetCameraYaw;
+  (
+    ident: 'GetCameraPitch',
+    returnType: 'number',
+    argTypes: [],
+  ): GetCameraPitch;
 }
 
 export interface SolarSystemModuleConfig {
@@ -349,6 +361,8 @@ declare global {
     getCameraPositionX?: GetCameraPositionComponent;
     getCameraPositionY?: GetCameraPositionComponent;
     getCameraPositionZ?: GetCameraPositionComponent;
+    getCameraYaw?: GetCameraYaw;
+    getCameraPitch?: GetCameraPitch;
     onPlanetFocused?: (index: number) => void;
     __solarSystemAssetBase?: string;
   }

--- a/web/src/deepLink.ts
+++ b/web/src/deepLink.ts
@@ -1,0 +1,238 @@
+import type { OrbitScaleMode, PlanetIndex, QualityPreset } from './SolarSystem.js';
+
+export interface DeepLinkViewState {
+    quality?: QualityPreset;
+    timeScale?: number;
+    paused?: boolean;
+    simulationDate?: string;
+    orbitScale?: OrbitScaleMode;
+    shadows?: boolean;
+    orbitLines?: boolean;
+    planet?: PlanetIndex;
+    camera?: {
+        x: number;
+        y: number;
+        z: number;
+        yaw: number;
+        pitch: number;
+    };
+}
+
+export interface DeepLinkRuntimeReaders {
+    getQualityPreset?: () => QualityPreset;
+    getTimeScale?: () => number;
+    getPaused?: () => number;
+    getSimulationEpoch?: () => number;
+    getOrbitScaleMode?: () => OrbitScaleMode;
+    getShadowQuality?: () => number;
+    getOrbitLines?: () => number;
+    getFocusedPlanetIndex?: () => number;
+    getCameraPosition?: () => { x: number; y: number; z: number };
+    getCameraYaw?: () => number;
+    getCameraPitch?: () => number;
+    isoDateFromJulianDate?: (jd: number) => string;
+}
+
+const PLANET_IDS: Record<string, PlanetIndex> = {
+    sun: 0,
+    mercury: 1,
+    venus: 2,
+    earth: 3,
+    mars: 4,
+    jupiter: 5,
+    saturn: 6,
+    uranus: 7,
+    neptune: 8,
+    pluto: 9,
+};
+
+const PLANET_ID_BY_INDEX = Object.fromEntries(
+    Object.entries(PLANET_IDS).map(([id, index]) => [index, id]),
+) as Record<PlanetIndex, string>;
+
+function parseFiniteNumber(value: string | null): number | undefined {
+    if (!value) return undefined;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseBooleanParam(value: string | null): boolean | undefined {
+    if (!value) return undefined;
+    const normalized = value.toLowerCase();
+    if (normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on') {
+        return true;
+    }
+    if (normalized === '0' || normalized === 'false' || normalized === 'no' || normalized === 'off') {
+        return false;
+    }
+    return undefined;
+}
+
+function parseQuality(value: string | null): QualityPreset | undefined {
+    if (!value) return undefined;
+    const normalized = value.toLowerCase();
+    if (normalized === 'low' || normalized === '0') return 0;
+    if (normalized === 'medium' || normalized === 'med' || normalized === '1') return 1;
+    if (normalized === 'full' || normalized === '2') return 2;
+    const asNumber = Number(value);
+    if (asNumber === 0 || asNumber === 1 || asNumber === 2) return asNumber;
+    return undefined;
+}
+
+function parsePlanetIndex(value: string | null): PlanetIndex | undefined {
+    if (!value) return undefined;
+    const normalized = value.toLowerCase();
+    if (normalized in PLANET_IDS) {
+        return PLANET_IDS[normalized];
+    }
+    const asNumber = Number(value);
+    if (Number.isInteger(asNumber) && asNumber >= 0 && asNumber <= 9) {
+        return asNumber as PlanetIndex;
+    }
+    return undefined;
+}
+
+function parseOrbitScale(value: string | null): OrbitScaleMode | undefined {
+    if (!value) return undefined;
+    const normalized = value.toLowerCase();
+    if (normalized === 'compressed' || normalized === 'art' || normalized === '0') return 0;
+    if (normalized === 'realistic' || normalized === 'au' || normalized === '1') return 1;
+    const asNumber = Number(value);
+    if (asNumber === 0 || asNumber === 1) return asNumber;
+    return undefined;
+}
+
+function parseSimulationDate(value: string | null): string | undefined {
+    if (!value) return undefined;
+    return /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : undefined;
+}
+
+function roundCoord(value: number): number {
+    return Math.round(value * 100) / 100;
+}
+
+function roundAngle(value: number): number {
+    return Math.round(value * 10) / 10;
+}
+
+/** Parse shareable view state from the current page URL. */
+export function parseDeepLinkFromUrl(search = window.location.search): DeepLinkViewState {
+    const params = new URLSearchParams(search);
+    const quality = parseQuality(params.get('quality') ?? params.get('q'));
+    const timeScale = parseFiniteNumber(params.get('time') ?? params.get('ts'));
+    const paused = parseBooleanParam(params.get('paused') ?? params.get('p'));
+    const simulationDate = parseSimulationDate(params.get('date'));
+    const orbitScale = parseOrbitScale(params.get('orbit') ?? params.get('scale'));
+    const shadows = parseBooleanParam(params.get('shadows'));
+    const orbitLines = parseBooleanParam(params.get('orbits') ?? params.get('orbitLines'));
+    const planet = parsePlanetIndex(params.get('planet') ?? params.get('focus'));
+
+    const x = parseFiniteNumber(params.get('x'));
+    const y = parseFiniteNumber(params.get('y'));
+    const z = parseFiniteNumber(params.get('z'));
+    const yaw = parseFiniteNumber(params.get('yaw'));
+    const pitch = parseFiniteNumber(params.get('pitch'));
+    const camera = x !== undefined && y !== undefined && z !== undefined
+        && yaw !== undefined && pitch !== undefined
+        ? { x, y, z, yaw, pitch }
+        : undefined;
+
+    return {
+        quality,
+        timeScale,
+        paused,
+        simulationDate,
+        orbitScale,
+        shadows,
+        orbitLines,
+        planet,
+        camera,
+    };
+}
+
+export function hasDeepLinkViewState(state: DeepLinkViewState): boolean {
+    return Object.values(state).some((value) => value !== undefined);
+}
+
+/** Build a shareable URL for the current simulation view. */
+export function buildShareableUrl(
+    readers: DeepLinkRuntimeReaders,
+    baseUrl = window.location.href,
+): string {
+    const url = new URL(baseUrl);
+    url.search = '';
+
+    const quality = readers.getQualityPreset?.();
+    if (quality !== undefined) {
+        url.searchParams.set('quality', String(quality));
+    }
+
+    const timeScale = readers.getTimeScale?.();
+    if (timeScale !== undefined && Number.isFinite(timeScale)) {
+        url.searchParams.set('time', String(roundCoord(timeScale)));
+    }
+
+    const paused = readers.getPaused?.();
+    if (paused !== undefined) {
+        url.searchParams.set('paused', paused ? '1' : '0');
+    }
+
+    const jd = readers.getSimulationEpoch?.();
+    if (jd !== undefined && Number.isFinite(jd) && readers.isoDateFromJulianDate) {
+        url.searchParams.set('date', readers.isoDateFromJulianDate(jd));
+    }
+
+    const orbitScale = readers.getOrbitScaleMode?.();
+    if (orbitScale !== undefined) {
+        url.searchParams.set('orbit', String(orbitScale));
+    }
+
+    const shadowQuality = readers.getShadowQuality?.();
+    if (shadowQuality !== undefined) {
+        url.searchParams.set('shadows', shadowQuality > 0 ? '1' : '0');
+    }
+
+    const orbitLines = readers.getOrbitLines?.();
+    if (orbitLines !== undefined) {
+        url.searchParams.set('orbits', orbitLines ? '1' : '0');
+    }
+
+    const focusedPlanet = readers.getFocusedPlanetIndex?.() ?? -1;
+    if (focusedPlanet >= 0 && focusedPlanet <= 9) {
+        url.searchParams.set('planet', PLANET_ID_BY_INDEX[focusedPlanet as PlanetIndex]);
+    }
+
+    const position = readers.getCameraPosition?.();
+    const yaw = readers.getCameraYaw?.();
+    const pitch = readers.getCameraPitch?.();
+    if (position && yaw !== undefined && pitch !== undefined) {
+        url.searchParams.set('x', String(roundCoord(position.x)));
+        url.searchParams.set('y', String(roundCoord(position.y)));
+        url.searchParams.set('z', String(roundCoord(position.z)));
+        url.searchParams.set('yaw', String(roundAngle(yaw)));
+        url.searchParams.set('pitch', String(roundAngle(pitch)));
+    }
+
+    return url.toString();
+}
+
+export async function copyShareableLink(
+    readers: DeepLinkRuntimeReaders,
+    baseUrl = window.location.href,
+): Promise<string> {
+    const link = buildShareableUrl(readers, baseUrl);
+    if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(link);
+    } else {
+        const textarea = document.createElement('textarea');
+        textarea.value = link;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'fixed';
+        textarea.style.left = '-9999px';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        textarea.remove();
+    }
+    return link;
+}

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -8,6 +8,7 @@ import Module, {
 import { initTouchControls, isMobileLikeDevice } from './touchControls'
 import { PlanetExplorer } from './planetExplorer'
 import { initWebXr } from './webxr'
+import { copyShareableLink, parseDeepLinkFromUrl } from './deepLink'
 
 // Emscripten 6 prefers resizable WebAssembly buffers when the browser exposes
 // toResizableBuffer(). Current Chrome DOM/WebGL APIs reject views backed by
@@ -47,6 +48,7 @@ const musicVolumeInput = document.getElementById('music-volume') as HTMLInputEle
 const musicVolumeValue = document.getElementById('music-volume-value') as HTMLOutputElement;
 const musicMutedInput = document.getElementById('music-muted') as HTMLInputElement;
 const settingsReset = document.getElementById('settings-reset') as HTMLButtonElement;
+const copyViewLinkButton = document.getElementById('copy-view-link') as HTMLButtonElement;
 const settingsStatus = document.getElementById('settings-status') as HTMLElement;
 const enterVrButton = document.getElementById('enter-vr') as HTMLButtonElement;
 const exitVrButton = document.getElementById('exit-vr') as HTMLButtonElement;
@@ -271,15 +273,25 @@ function syncSimulationDateFromRuntime(): void {
     simulationDateInput.value = isoDateFromJulianDate(jd);
 }
 
-function qualityFromUrl(): QualityPreset | undefined {
-    const params = new URLSearchParams(window.location.search);
-    const value = params.get('quality') ?? params.get('q');
-    if (!value) return undefined;
-    const normalized = value.toLowerCase();
-    if (normalized === 'low' || normalized === '0') return 0;
-    if (normalized === 'medium' || normalized === 'med' || normalized === '1') return 1;
-    if (normalized === 'full' || normalized === '2') return 2;
-    return undefined;
+function deepLinkReaders() {
+    return {
+        getQualityPreset: () => (window.getQualityPreset?.() ?? 2) as QualityPreset,
+        getTimeScale: () => window.getTimeScale?.() ?? 1,
+        getPaused: () => window.getPaused?.() ?? 0,
+        getSimulationEpoch: () => window.getSimulationEpoch?.() ?? 0,
+        getOrbitScaleMode: () => (window.getOrbitScaleMode?.() ?? 0) as OrbitScaleMode,
+        getShadowQuality: () => window.getShadowQuality?.() ?? 0,
+        getOrbitLines: () => window.getOrbitLines?.() ?? 0,
+        getFocusedPlanetIndex: () => window.getFocusedPlanetIndex?.() ?? -1,
+        getCameraPosition: () => ({
+            x: window.getCameraPositionX?.() ?? 0,
+            y: window.getCameraPositionY?.() ?? 0,
+            z: window.getCameraPositionZ?.() ?? 0,
+        }),
+        getCameraYaw: () => window.getCameraYaw?.() ?? -90,
+        getCameraPitch: () => window.getCameraPitch?.() ?? 0,
+        isoDateFromJulianDate,
+    };
 }
 
 function setPanelCollapsed(collapsed: boolean): void {
@@ -360,7 +372,10 @@ Module(moduleConfig).then((instance) => {
     window.getCameraPositionX = instance.cwrap('GetCameraPositionX', 'number', []);
     window.getCameraPositionY = instance.cwrap('GetCameraPositionY', 'number', []);
     window.getCameraPositionZ = instance.cwrap('GetCameraPositionZ', 'number', []);
+    window.getCameraYaw = instance.cwrap('GetCameraYaw', 'number', []);
+    window.getCameraPitch = instance.cwrap('GetCameraPitch', 'number', []);
 
+    const deepLink = parseDeepLinkFromUrl();
     const explorer = new PlanetExplorer(explorerPanel);
     void explorer.init({
         focusPlanet: window.focusPlanet,
@@ -369,6 +384,9 @@ Module(moduleConfig).then((instance) => {
         getPlanetSceneDistance: window.getPlanetSceneDistance,
         getOrbitScaleMode: () => (window.getOrbitScaleMode?.() ?? 0) as OrbitScaleMode,
         setOrbitScaleMode: window.setOrbitScaleMode,
+    }, {
+        skipPlanetRestore: deepLink.planet !== undefined || deepLink.camera !== undefined,
+        initialOrbitScale: deepLink.orbitScale,
     }).catch((error: unknown) => {
         console.error('Failed to initialize planet explorer:', error);
     });
@@ -447,18 +465,19 @@ Module(moduleConfig).then((instance) => {
     });
 
     const saved = readPersistedSettings();
-    // An explicit URL preset wins for shareable links. On mobile, default to low
-    // when nothing was saved. Otherwise restore the user's choice.
+    // URL params win for shareable links, then localStorage, then defaults.
     const defaultQuality: QualityPreset = isMobileDevice ? 0 : 2;
-    const quality = qualityFromUrl() ?? saved.quality ?? defaultQuality;
-    const timeScale = saved.timeScale ?? window.getTimeScale();
-    const paused = saved.paused ?? Boolean(window.getPaused());
-    const shadows = saved.shadows ?? true;
-    const orbitLines = saved.orbitLines ?? true;
+    const quality = deepLink.quality ?? saved.quality ?? defaultQuality;
+    const timeScale = deepLink.timeScale ?? saved.timeScale ?? window.getTimeScale();
+    const paused = deepLink.paused ?? saved.paused ?? Boolean(window.getPaused());
+    const shadows = deepLink.shadows ?? saved.shadows ?? true;
+    const orbitLines = deepLink.orbitLines ?? saved.orbitLines ?? true;
     const musicVolumePercent = saved.musicVolume ?? Math.round((window.getMusicVolume?.() ?? 0.3) * 100);
     const musicMuted = saved.musicMuted ?? Boolean(window.getMusicMuted?.());
-    const simulationDate = saved.simulationDate
+    const simulationDate = deepLink.simulationDate
+        ?? saved.simulationDate
         ?? (window.getSimulationEpoch ? isoDateFromJulianDate(window.getSimulationEpoch()) : isoDateUtcNow());
+    const orbitScale = deepLink.orbitScale;
 
     qualitySelect.value = String(quality);
     timeScaleInput.value = String(Math.log10(timeScale));
@@ -473,6 +492,9 @@ Module(moduleConfig).then((instance) => {
     window.setQualityPreset(quality);
     window.setTimeScale(timeScale);
     window.setPaused(paused);
+    if (orbitScale === 0 || orbitScale === 1) {
+        window.setOrbitScaleMode?.(orbitScale);
+    }
     {
         const jd = julianDateFromIsoDate(simulationDate);
         if (jd !== undefined) {
@@ -485,6 +507,22 @@ Module(moduleConfig).then((instance) => {
     if (!musicMuted) {
         window.setMusicVolume?.(musicVolumePercent / 100);
     }
+
+    if (deepLink.camera) {
+        window.setCameraPose?.(
+            deepLink.camera.x,
+            deepLink.camera.y,
+            deepLink.camera.z,
+            deepLink.camera.yaw,
+            deepLink.camera.pitch,
+        );
+    } else if (deepLink.planet !== undefined) {
+        window.focusPlanet?.(deepLink.planet);
+    }
+    if (deepLink.planet !== undefined) {
+        explorer.applyDeepLinkPlanet(deepLink.planet, { focusCamera: false });
+    }
+
     settingsFieldset.disabled = false;
     settingsStatus.textContent = 'Controls ready';
     persistPanelSettings();
@@ -557,6 +595,17 @@ Module(moduleConfig).then((instance) => {
         }
         settingsStatus.textContent = musicMutedInput.checked ? 'Music muted' : 'Music unmuted';
         persistPanelSettings();
+    });
+
+    copyViewLinkButton.addEventListener('click', () => {
+        void copyShareableLink(deepLinkReaders())
+            .then(() => {
+                settingsStatus.textContent = 'View link copied to clipboard';
+            })
+            .catch((error: unknown) => {
+                console.warn('[DeepLink] copy failed:', error);
+                settingsStatus.textContent = 'Could not copy link';
+            });
     });
 
     settingsReset.addEventListener('click', () => {

--- a/web/src/planetExplorer.ts
+++ b/web/src/planetExplorer.ts
@@ -4,20 +4,28 @@ export interface PlanetFactBody {
     index: PlanetIndex;
     id: string;
     name: string;
+    nameRu?: string;
     type: string;
     diameterKm: number;
     massEarths?: number;
+    siderealRotationDays?: number;
     orbitalPeriodDays: number | null;
     distanceAu: number;
     moons?: number;
     summary: string;
+    summaryRu?: string;
 }
 
 export interface PlanetFactsFile {
     version: number;
     sceneNote?: string;
     bodies: PlanetFactBody[];
-    scaleModes: Record<string, { label: string; description: string }>;
+    scaleModes: Record<string, {
+        label: string;
+        labelRu?: string;
+        description: string;
+        descriptionRu?: string;
+    }>;
 }
 
 export interface PlanetExplorerBindings {
@@ -35,7 +43,9 @@ interface PlanetExplorerElements {
     toggleIcon: HTMLElement;
     bodyList: HTMLElement;
     card: HTMLElement;
+    cardHeader: HTMLElement;
     cardTitle: HTMLElement;
+    cardDismiss: HTMLButtonElement;
     cardSummary: HTMLElement;
     cardFacts: HTMLElement;
     scaleSelect: HTMLSelectElement;
@@ -45,23 +55,90 @@ interface PlanetExplorerElements {
 
 const EXPLORER_STORAGE_KEY = 'solar-system.explorer.v1';
 
-function formatDiameter(km: number): string {
-    if (km >= 10000) {
-        return `${km.toLocaleString()} km`;
-    }
-    return `${km.toLocaleString(undefined, { maximumFractionDigits: 0 })} km`;
+type ExplorerLocale = 'en' | 'ru';
+
+const LABELS: Record<ExplorerLocale, Record<string, string>> = {
+    en: {
+        type: 'Type',
+        diameter: 'Diameter',
+        mass: 'Mass (Earths)',
+        dayLength: 'Day length',
+        orbitalPeriod: 'Orbital period',
+        distanceFromSun: 'Distance from Sun',
+        sceneDistance: 'Scene distance',
+        scaleMode: 'Scale mode',
+        knownMoons: 'Known moons',
+        centerOfSystem: 'Center of system',
+        retrograde: 'retrograde',
+        compressedSpacing: 'Compressed spacing',
+        realisticSpacing: 'Realistic spacing',
+        dismissCard: 'Dismiss info card',
+        focused: 'Focused',
+    },
+    ru: {
+        type: 'Тип',
+        diameter: 'Диаметр',
+        mass: 'Масса (Земли)',
+        dayLength: 'Длина суток',
+        orbitalPeriod: 'Орбитальный период',
+        distanceFromSun: 'Расстояние от Солнца',
+        sceneDistance: 'Расстояние в сцене',
+        scaleMode: 'Режим масштаба',
+        knownMoons: 'Известные спутники',
+        centerOfSystem: 'Центр системы',
+        retrograde: 'ретроградное',
+        compressedSpacing: 'Сжатые орбиты',
+        realisticSpacing: 'Реалистичные расстояния',
+        dismissCard: 'Закрыть карточку',
+        focused: 'Фокус',
+    },
+};
+
+function detectLocale(): ExplorerLocale {
+    const lang = (navigator.language || 'en').toLowerCase();
+    return lang.startsWith('ru') ? 'ru' : 'en';
 }
 
-function formatOrbitalPeriod(days: number | null): string {
+function formatDiameter(km: number, locale: ExplorerLocale): string {
+    const formatted = km >= 10000
+        ? km.toLocaleString(locale === 'ru' ? 'ru-RU' : 'en-US')
+        : km.toLocaleString(locale === 'ru' ? 'ru-RU' : 'en-US', { maximumFractionDigits: 0 });
+    return `${formatted} km`;
+}
+
+function formatOrbitalPeriod(days: number | null, locale: ExplorerLocale): string {
     if (days === null) return '—';
-    if (days < 400) return `${days.toLocaleString()} days`;
+    if (days < 400) {
+        return locale === 'ru'
+            ? `${days.toLocaleString('ru-RU')} сут.`
+            : `${days.toLocaleString()} days`;
+    }
     const years = days / 365.25;
-    if (years < 10) return `${years.toFixed(1)} years`;
-    return `${Math.round(years).toLocaleString()} years`;
+    if (years < 10) {
+        return locale === 'ru' ? `${years.toFixed(1)} лет` : `${years.toFixed(1)} years`;
+    }
+    return locale === 'ru'
+        ? `${Math.round(years).toLocaleString('ru-RU')} лет`
+        : `${Math.round(years).toLocaleString()} years`;
 }
 
-function formatSceneDistance(units: number): string {
-    return `${Math.round(units).toLocaleString()} scene units`;
+function formatDayLength(days: number | undefined, locale: ExplorerLocale): string {
+    if (days === undefined) return '—';
+    const retrograde = days < 0;
+    const absDays = Math.abs(days);
+    const hours = absDays * 24;
+    const suffix = retrograde ? ` (${LABELS[locale].retrograde})` : '';
+    if (hours < 48) {
+        return `${hours.toFixed(1)} h${suffix}`;
+    }
+    return locale === 'ru'
+        ? `${absDays.toFixed(2)} сут.${suffix}`
+        : `${absDays.toFixed(2)} days${suffix}`;
+}
+
+function formatSceneDistance(units: number, locale: ExplorerLocale): string {
+    const rounded = Math.round(units).toLocaleString(locale === 'ru' ? 'ru-RU' : 'en-US');
+    return locale === 'ru' ? `${rounded} ед. сцены` : `${rounded} scene units`;
 }
 
 export class PlanetExplorer {
@@ -69,15 +146,22 @@ export class PlanetExplorer {
     private facts: PlanetFactsFile | null = null;
     private bindings: PlanetExplorerBindings = {};
     private selectedIndex: PlanetIndex | null = null;
+    private cardDismissed = false;
+    private readonly locale: ExplorerLocale;
+    private skipPlanetRestore = false;
+    private initialOrbitScale: OrbitScaleMode | undefined;
 
     constructor(root: HTMLElement) {
+        this.locale = detectLocale();
         this.elements = {
             panel: root,
             toggle: root.querySelector('#explorer-toggle') as HTMLButtonElement,
             toggleIcon: root.querySelector('.explorer-toggle-icon') as HTMLElement,
             bodyList: root.querySelector('#explorer-body-list') as HTMLElement,
             card: root.querySelector('#planet-info-card') as HTMLElement,
+            cardHeader: root.querySelector('#planet-info-header') as HTMLElement,
             cardTitle: root.querySelector('#planet-info-title') as HTMLElement,
+            cardDismiss: root.querySelector('#planet-info-dismiss') as HTMLButtonElement,
             cardSummary: root.querySelector('#planet-info-summary') as HTMLElement,
             cardFacts: root.querySelector('#planet-info-facts') as HTMLElement,
             scaleSelect: root.querySelector('#orbit-scale-mode') as HTMLSelectElement,
@@ -87,6 +171,10 @@ export class PlanetExplorer {
 
         this.elements.toggle.addEventListener('click', () => {
             this.setCollapsed(this.elements.panel.classList.contains('is-collapsed') === false);
+        });
+
+        this.elements.cardDismiss.addEventListener('click', () => {
+            this.dismissCard();
         });
 
         for (const eventName of ['pointerdown', 'pointerup', 'click', 'keydown', 'keyup']) {
@@ -104,22 +192,54 @@ export class PlanetExplorer {
         });
     }
 
-    async init(bindings: PlanetExplorerBindings): Promise<void> {
+    async init(
+        bindings: PlanetExplorerBindings,
+        options?: { skipPlanetRestore?: boolean; initialOrbitScale?: OrbitScaleMode },
+    ): Promise<void> {
         this.bindings = bindings;
+        this.skipPlanetRestore = options?.skipPlanetRestore ?? false;
+        this.initialOrbitScale = options?.initialOrbitScale;
         const factsUrl = new URL('planet_facts.json', import.meta.env.BASE_URL).toString();
         const response = await fetch(factsUrl);
         if (!response.ok) {
             throw new Error(`Failed to load planet facts (${response.status})`);
         }
         this.facts = await response.json() as PlanetFactsFile;
+        this.elements.cardDismiss.setAttribute('aria-label', LABELS[this.locale].dismissCard);
         this.renderBodyList();
-        this.restoreState();
+        if (!this.skipPlanetRestore) {
+            this.restoreState();
+        } else {
+            this.restoreState({ skipPlanet: true, skipScale: this.initialOrbitScale !== undefined });
+        }
+        if (this.initialOrbitScale === 0 || this.initialOrbitScale === 1) {
+            this.elements.scaleSelect.value = String(this.initialOrbitScale);
+            this.updateScaleHelp();
+        }
         this.syncScaleFromRuntime();
         this.elements.status.textContent = 'Explorer ready';
         this.startPolling();
         window.onPlanetFocused = (index: number) => {
-            this.selectPlanet(index as PlanetIndex, { focusCamera: false });
+            this.onExternalFocus(index as PlanetIndex);
         };
+    }
+
+    applyDeepLinkPlanet(index: PlanetIndex, options: { focusCamera: boolean }): void {
+        this.cardDismissed = false;
+        this.selectPlanet(index, options);
+        this.setCollapsed(false);
+    }
+
+    private onExternalFocus(index: PlanetIndex): void {
+        this.cardDismissed = false;
+        this.selectPlanet(index, { focusCamera: false });
+        this.setCollapsed(false);
+    }
+
+    private dismissCard(): void {
+        this.cardDismissed = true;
+        this.elements.card.hidden = true;
+        this.elements.card.classList.remove('is-focused');
     }
 
     private startPolling(): void {
@@ -144,8 +264,19 @@ export class PlanetExplorer {
     private updateScaleHelp(): void {
         const mode = Number(this.elements.scaleSelect.value);
         const key = mode === 1 ? 'realistic' : 'compressed';
-        const description = this.facts?.scaleModes[key]?.description ?? '';
+        const entry = this.facts?.scaleModes[key];
+        const description = this.locale === 'ru'
+            ? entry?.descriptionRu ?? entry?.description ?? ''
+            : entry?.description ?? '';
         this.elements.scaleHelp.textContent = description;
+    }
+
+    private localizedName(body: PlanetFactBody): string {
+        return this.locale === 'ru' ? (body.nameRu ?? body.name) : body.name;
+    }
+
+    private localizedSummary(body: PlanetFactBody): string {
+        return this.locale === 'ru' ? (body.summaryRu ?? body.summary) : body.summary;
     }
 
     private renderBodyList(): void {
@@ -156,8 +287,9 @@ export class PlanetExplorer {
             button.type = 'button';
             button.className = 'explorer-body-btn';
             button.dataset.planetIndex = String(body.index);
-            button.textContent = body.name;
+            button.textContent = this.localizedName(body);
             button.addEventListener('click', () => {
+                this.cardDismissed = false;
                 this.selectPlanet(body.index, { focusCamera: true });
             });
             this.elements.bodyList.appendChild(button);
@@ -178,7 +310,8 @@ export class PlanetExplorer {
         this.renderCard(index);
         this.highlightSelection(index);
         this.persistState();
-        this.elements.status.textContent = `Focused ${this.facts?.bodies.find((b) => b.index === index)?.name ?? 'body'}`;
+        const body = this.facts?.bodies.find((entry) => entry.index === index);
+        this.elements.status.textContent = `${LABELS[this.locale].focused} ${body ? this.localizedName(body) : 'body'}`;
     }
 
     private highlightSelection(index: PlanetIndex): void {
@@ -191,34 +324,42 @@ export class PlanetExplorer {
 
     private renderCard(index: PlanetIndex): void {
         const body = this.facts?.bodies.find((entry) => entry.index === index);
-        if (!body) {
+        if (!body || this.cardDismissed) {
             this.elements.card.hidden = true;
+            this.elements.card.classList.remove('is-focused');
             return;
         }
 
+        const labels = LABELS[this.locale];
         const sceneDistance = this.bindings.getPlanetSceneDistance?.(index) ?? 0;
         const scaleMode = this.bindings.getOrbitScaleMode?.() ?? 0;
-        const scaleLabel = scaleMode === 1 ? 'Realistic spacing' : 'Compressed spacing';
+        const scaleLabel = scaleMode === 1 ? labels.realisticSpacing : labels.compressedSpacing;
 
         this.elements.card.hidden = false;
-        this.elements.cardTitle.textContent = body.name;
-        this.elements.cardSummary.textContent = body.summary;
+        this.elements.card.classList.add('is-focused');
+        this.elements.cardTitle.textContent = this.localizedName(body);
+        this.elements.cardSummary.textContent = this.localizedSummary(body);
 
         const factRows: Array<[string, string]> = [
-            ['Type', body.type.replace(/_/g, ' ')],
-            ['Diameter', formatDiameter(body.diameterKm)],
-            ['Orbital period', formatOrbitalPeriod(body.orbitalPeriodDays)],
-            ['Distance from Sun', body.distanceAu > 0 ? `${body.distanceAu} AU` : 'Center of system'],
-            ['Scene distance', formatSceneDistance(sceneDistance)],
-            ['Scale mode', scaleLabel],
+            [labels.type, body.type.replace(/_/g, ' ')],
+            [labels.diameter, formatDiameter(body.diameterKm, this.locale)],
+            [labels.dayLength, formatDayLength(body.siderealRotationDays, this.locale)],
+            [labels.distanceFromSun, body.distanceAu > 0 ? `${body.distanceAu} AU` : labels.centerOfSystem],
         ];
 
         if (body.moons !== undefined) {
-            factRows.push(['Known moons', String(body.moons)]);
+            factRows.push([labels.knownMoons, String(body.moons)]);
         }
         if (body.massEarths !== undefined && body.index > 0) {
-            factRows.push(['Mass (Earths)', body.massEarths.toLocaleString()]);
+            factRows.push([labels.mass, body.massEarths.toLocaleString(this.locale === 'ru' ? 'ru-RU' : 'en-US')]);
         }
+        if (body.orbitalPeriodDays !== null) {
+            factRows.push([labels.orbitalPeriod, formatOrbitalPeriod(body.orbitalPeriodDays, this.locale)]);
+        }
+        factRows.push(
+            [labels.sceneDistance, formatSceneDistance(sceneDistance, this.locale)],
+            [labels.scaleMode, scaleLabel],
+        );
 
         this.elements.cardFacts.replaceChildren();
         for (const [label, value] of factRows) {
@@ -252,7 +393,7 @@ export class PlanetExplorer {
         }
     }
 
-    private restoreState(): void {
+    private restoreState(options?: { skipPlanet?: boolean; skipScale?: boolean }): void {
         try {
             const raw = window.localStorage.getItem(EXPLORER_STORAGE_KEY);
             if (!raw) return;
@@ -264,12 +405,12 @@ export class PlanetExplorer {
             if (typeof parsed.collapsed === 'boolean') {
                 this.setCollapsed(parsed.collapsed);
             }
-            if (parsed.scaleMode === 0 || parsed.scaleMode === 1) {
+            if (!options?.skipScale && (parsed.scaleMode === 0 || parsed.scaleMode === 1)) {
                 this.elements.scaleSelect.value = String(parsed.scaleMode);
                 this.bindings.setOrbitScaleMode?.(parsed.scaleMode);
                 this.updateScaleHelp();
             }
-            if (parsed.selectedIndex !== undefined) {
+            if (!options?.skipPlanet && parsed.selectedIndex !== undefined) {
                 this.selectPlanet(parsed.selectedIndex, { focusCamera: false });
             }
         } catch {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -252,6 +252,23 @@ input {
   background: rgba(255, 255, 255, 0.13);
 }
 
+.settings-share {
+  width: 100%;
+  min-height: 44px;
+  margin-top: 8px;
+  color: #e8f7ff;
+  background: rgba(30, 90, 130, 0.35);
+  border: 1px solid rgba(120, 200, 255, 0.35);
+  border-radius: 8px;
+  cursor: pointer;
+  touch-action: manipulation;
+  font-weight: 600;
+}
+
+.settings-share:hover {
+  background: rgba(40, 110, 160, 0.45);
+}
+
 .settings-vr {
   width: 100%;
   min-height: 44px;
@@ -402,9 +419,42 @@ input {
   border-radius: 10px;
 }
 
+.planet-info-card.is-focused {
+  border-color: rgba(137, 209, 255, 0.45);
+  box-shadow: 0 0 0 1px rgba(137, 209, 255, 0.12);
+}
+
+.planet-info-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
 .planet-info-title {
-  margin: 0 0 8px;
+  margin: 0;
   font-size: 1.2rem;
+  line-height: 1.25;
+}
+
+.planet-info-dismiss {
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  color: #c7e9ff;
+  font-size: 1.4rem;
+  line-height: 1;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(137, 209, 255, 0.2);
+  border-radius: 8px;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.planet-info-dismiss:hover {
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .planet-info-summary {
@@ -463,6 +513,7 @@ input {
   .settings-slider,
   .settings-switch,
   .settings-reset,
+  .settings-share,
   .settings-date-btn {
     min-height: 48px;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds two UX improvements on top of state the app already exposes:

1. **Shareable deep-links** — camera pose, focused planet, orbit scale, time scale, simulation date, and quality are encoded in URL query params. A **Copy link to this view** button in the settings panel copies the current view. Restore order is **URL params → localStorage → defaults** (matching the existing `?quality=` precedent).

2. **Expanded educational info overlay** — the Planet Explorer info card now shows diameter, mass, day length, distance from Sun, moon count, and a one-line description with **EN/RU localization** (auto-detected from `navigator.language`). A dismiss button hides the card without leaking input to GLFW (`stopPropagation` unchanged).

## Changes

- `web/src/deepLink.ts` — parse/serialize view state, clipboard copy helper
- `web/src/main.ts` — wire deep-link restore + copy button; export `GetCameraYaw`/`GetCameraPitch`
- `src/Application.cpp` + `Camera.h` — WASM exports for camera yaw/pitch
- `web/src/planetExplorer.ts` — richer info card, dismiss, locale, focus handling
- `web/public/planet_facts.json` — `nameRu`, `summaryRu`, `siderealRotationDays` (NASA averages)
- `web/index.html` / `web/src/style.css` — copy-link button + card header/dismiss styles

## Example URL

```
/solar-system/?quality=2&time=10&paused=0&date=2026-07-21&orbit=0&planet=earth&x=1200&y=50&z=-300&yaw=-45&pitch=-10
```

## Test plan

- [x] `npx tsc` passes
- [x] `./build-web.sh` succeeds with new `GetCameraYaw`/`GetCameraPitch` exports
- [ ] Paste a copied link in a fresh tab — camera, planet focus, and settings match
- [ ] Focus a planet — info card appears with facts; dismiss hides it; overlay input does not move camera
- [ ] Russian locale (`ru`) shows RU names/labels when browser language is Russian

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd5693e5-9a00-4040-9634-ab8841daacf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd5693e5-9a00-4040-9634-ab8841daacf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shareable links that preserve simulation settings, selected planets, dates, and camera views.
  - Added a “Copy link to this view” option in Settings.
  - Added camera orientation support when restoring shared views.
  - Added a dismiss button for the planet information card.
  - Added Russian localization for planet information and display settings.

- **Improvements**
  - Planet details now adapt to the selected locale with localized labels and formatting.
  - Shared links can restore orbit scale, simulation state, and camera position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->